### PR TITLE
APL-344 - Fix arm architecture detection for updater and fix vbs start scripts

### DIFF
--- a/src/main/java/com/apollocurrency/aplwallet/apl/updater/Architecture.java
+++ b/src/main/java/com/apollocurrency/aplwallet/apl/updater/Architecture.java
@@ -18,7 +18,7 @@ public enum Architecture {
             case "x86" :
                 return X86;
         }
-        if (osArch.startsWith("arm")) {
+        if (osArch.startsWith("arm") || osArch.startsWith("aarch64")) {
             return ARM;
         }
         return null;

--- a/start-desktop.vbs
+++ b/start-desktop.vbs
@@ -1,2 +1,2 @@
 Set WshShell = CreateObject("WScript.Shell") 
-WshShell.Run CreateObject("Scripting.FileSystemObject").GetParentFolderName(WScript.ScriptFullName) & "\run-desktop.bat", 0, false
+WshShell.Run chr(34) & CreateObject("Scripting.FileSystemObject").GetParentFolderName(WScript.ScriptFullName) & "\run-desktop.bat" & chr(34), 0, false

--- a/start.vbs
+++ b/start.vbs
@@ -1,2 +1,2 @@
 Set WshShell = CreateObject("WScript.Shell") 
-WshShell.Run CreateObject("Scripting.FileSystemObject").GetParentFolderName(WScript.ScriptFullName) & "\run.bat", 0, false
+WshShell.Run chr(34) & CreateObject("Scripting.FileSystemObject").GetParentFolderName(WScript.ScriptFullName) & "\run.bat" & chr(34), 0, false


### PR DESCRIPTION
Arm architecture represented not only by 'arm...' definitions. For example: x64 arm architecture has another definition - aarch64.

Windows full path may has whitespaces. Added chr(34) at the beginning and end of path to solve problem