### PR TITLE
APL-355 - Add error alert if api or peer port is busy

### DIFF
--- a/src/main/java/com/apollocurrency/aplwallet/apl/Constants.java
+++ b/src/main/java/com/apollocurrency/aplwallet/apl/Constants.java
@@ -150,6 +150,13 @@ public final class Constants {
     public static final Version MIN_VERSION = new Version(1, 0, 0);
     public static final Version MIN_PROXY_VERSION = new Version(1, 0, 0);
 
+//    Testnet ports
+    public static final int TESTNET_API_PORT = 6876;
+    public static final int TESTNET_API_SSLPORT = 6877;
+//    Peer ports
+    public static final int DEFAULT_PEER_PORT = 47874;
+    public static final int TESTNET_PEER_PORT = 46874;
+
     static final long UNCONFIRMED_POOL_DEPOSIT_ATM = (isTestnet ? 50 : 100) * ONE_APL;
     public static final long SHUFFLING_DEPOSIT_ATM = (isTestnet ? 7 : 1000) * ONE_APL;
 

--- a/src/main/java/com/apollocurrency/aplwallet/apl/env/CommandLineMode.java
+++ b/src/main/java/com/apollocurrency/aplwallet/apl/env/CommandLineMode.java
@@ -62,4 +62,14 @@ public class CommandLineMode implements RuntimeMode {
             System.exit(1);
         }
     }
+
+    @Override
+    public void updateAppStatus(String newStatus) {
+        LOG.info("Application status:", newStatus);
+    }
+
+    @Override
+    public void displayError(String errorMessage) {
+        LOG.error(errorMessage);
+    }
 }

--- a/src/main/java/com/apollocurrency/aplwallet/apl/env/DesktopMode.java
+++ b/src/main/java/com/apollocurrency/aplwallet/apl/env/DesktopMode.java
@@ -118,4 +118,15 @@ public class DesktopMode implements RuntimeMode {
             throw new RuntimeException("Unable to update status on splash screen!", e);
         }
     }
+
+    @Override
+    public void displayError(String errorMessage) {
+        try {
+            desktopAppClass.getMethod("showError", String.class).invoke(null, errorMessage);
+        }
+        catch (Exception e) {
+            //rethrow
+            throw new RuntimeException("Unable to show gui error alert!", e);
+        }
+    }
 }

--- a/src/main/java/com/apollocurrency/aplwallet/apl/env/RuntimeMode.java
+++ b/src/main/java/com/apollocurrency/aplwallet/apl/env/RuntimeMode.java
@@ -40,4 +40,6 @@ public interface RuntimeMode {
     }
 
     default void updateAppStatus(String newStatus) {}
+
+    void displayError(String errorMessage);
 }

--- a/src/main/java/com/apollocurrency/aplwallet/apl/http/API.java
+++ b/src/main/java/com/apollocurrency/aplwallet/apl/http/API.java
@@ -54,14 +54,14 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+import static com.apollocurrency.aplwallet.apl.Constants.TESTNET_API_PORT;
+import static com.apollocurrency.aplwallet.apl.Constants.TESTNET_API_SSLPORT;
 import static com.apollocurrency.aplwallet.apl.http.JSONResponses.*;
 import static org.slf4j.LoggerFactory.getLogger;
 
 public final class API {
     private static final Logger LOG = getLogger(API.class);
 
-    public static final int TESTNET_API_PORT = 6876;
-    public static final int TESTNET_API_SSLPORT = 6877;
     private static final String[] DISABLED_HTTP_METHODS = {"TRACE", "OPTIONS", "HEAD"};
     private static byte[] privateKey;
     private static byte[] publicKey;

--- a/src/main/java/com/apollocurrency/aplwallet/apl/mint/MintWorker.java
+++ b/src/main/java/com/apollocurrency/aplwallet/apl/mint/MintWorker.java
@@ -23,7 +23,6 @@ package com.apollocurrency.aplwallet.apl.mint;
 import com.apollocurrency.aplwallet.apl.*;
 import com.apollocurrency.aplwallet.apl.crypto.Crypto;
 import com.apollocurrency.aplwallet.apl.crypto.HashFunction;
-import com.apollocurrency.aplwallet.apl.http.API;
 import com.apollocurrency.aplwallet.apl.util.Convert;
 import com.apollocurrency.aplwallet.apl.util.TrustAllSSLProvider;
 import org.json.simple.JSONObject;
@@ -37,6 +36,7 @@ import java.net.*;
 import java.util.*;
 import java.util.concurrent.*;
 
+import static com.apollocurrency.aplwallet.apl.Constants.TESTNET_API_PORT;
 import static org.slf4j.LoggerFactory.getLogger;
 
 public class MintWorker {
@@ -217,7 +217,7 @@ public class MintWorker {
             HttpsURLConnection.setDefaultSSLSocketFactory(TrustAllSSLProvider.getSslSocketFactory());
             HttpsURLConnection.setDefaultHostnameVerifier(TrustAllSSLProvider.getHostNameVerifier());
         }
-        int port = Constants.isTestnet ? API.TESTNET_API_PORT : Apl.getIntProperty("apl.apiServerPort");
+        int port = Constants.isTestnet ? TESTNET_API_PORT : Apl.getIntProperty("apl.apiServerPort");
         String urlParams = getUrlParams(params);
         URL url;
         try {

--- a/src/main/java/com/apollocurrency/aplwallet/apl/peer/Peers.java
+++ b/src/main/java/com/apollocurrency/aplwallet/apl/peer/Peers.java
@@ -36,13 +36,14 @@ import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONStreamAware;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.servlet.DispatcherType;
 import java.net.*;
 import java.util.*;
 import java.util.concurrent.*;
 
+import static com.apollocurrency.aplwallet.apl.Constants.DEFAULT_PEER_PORT;
+import static com.apollocurrency.aplwallet.apl.Constants.TESTNET_PEER_PORT;
 import static org.slf4j.LoggerFactory.getLogger;
 
 public final class Peers {
@@ -76,8 +77,7 @@ public final class Peers {
     static final boolean useProxy = System.getProperty("socksProxyHost") != null || System.getProperty("http.proxyHost") != null;
     static final boolean isGzipEnabled;
 
-    private static final int DEFAULT_PEER_PORT = 47874;
-    private static final int TESTNET_PEER_PORT = 46874;
+
     private static final String myPlatform;
     private static final String myAddress;
     private static final int myPeerServerPort;

--- a/src/main/java/com/apollocurrency/aplwallet/apldesktop/DesktopApplication.java
+++ b/src/main/java/com/apollocurrency/aplwallet/apldesktop/DesktopApplication.java
@@ -30,6 +30,8 @@ import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.concurrent.Worker;
 import javafx.embed.swing.JFXPanel;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.Scene;
 import javafx.scene.control.Alert;
@@ -38,7 +40,9 @@ import javafx.scene.control.ButtonType;
 import javafx.scene.control.ProgressIndicator;
 import javafx.scene.image.Image;
 import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.HBox;
 import javafx.scene.text.Text;
+import javafx.scene.text.TextAlignment;
 import javafx.scene.web.WebEngine;
 import javafx.scene.web.WebView;
 import javafx.stage.Screen;
@@ -163,6 +167,25 @@ public class DesktopApplication extends Application {
             }
         }
         System.out.println("JavaFX platform shutdown complete");
+    }
+
+    public static void showError(String message) {
+        Platform.runLater(() -> {
+            Text text = new Text(message);
+            text.setWrappingWidth(330);
+            HBox hbox = new HBox();
+            hbox.setAlignment(Pos.CENTER);
+            hbox.setPadding(new Insets(10, 10, 0, 10));
+            hbox.getChildren().add(text);
+            text.setTextAlignment(TextAlignment.JUSTIFY);
+            Alert alert = new Alert(Alert.AlertType.ERROR);
+            alert.setHeaderText("Multiple Apollo wallets were launched");
+            alert.setWidth(350);
+            alert.setHeight(200);
+            alert.getDialogPane().setContent(hbox);
+            alert.showAndWait() ;
+            System.exit(0);
+        });
     }
 
     @Override


### PR DESCRIPTION
Using ServerSocket to capture (api, api-ssl, peer) ports and check availability. If error occurred while capturing port, javafx error alert will be shown. After that app will be closed automatically.
Moved port constants from Peers and API classes to Constants to prevent
static block initialization. Added logging of event and port error in
cmd mode.