### PR TITLE
Fix 2fa qrcode reading on iphone

### DIFF
--- a/src/main/java/com/apollocurrency/aplwallet/apl/TwoFactorAuthServiceImpl.java
+++ b/src/main/java/com/apollocurrency/aplwallet/apl/TwoFactorAuthServiceImpl.java
@@ -6,6 +6,10 @@ package com.apollocurrency.aplwallet.apl;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.security.GeneralSecurityException;
+
 import com.apollocurrency.aplwallet.apl.db.TwoFactorAuthEntity;
 import com.apollocurrency.aplwallet.apl.db.TwoFactorAuthRepository;
 import com.apollocurrency.aplwallet.apl.util.Convert;
@@ -13,14 +17,10 @@ import com.j256.twofactorauth.TimeBasedOneTimePasswordUtil;
 import org.apache.commons.codec.binary.Base32;
 import org.slf4j.Logger;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.security.GeneralSecurityException;
-
 public class TwoFactorAuthServiceImpl implements TwoFactorAuthService {
     private static final Logger LOG = getLogger(TwoFactorAuthServiceImpl.class);
     private static final Base32 BASE_32 = new Base32();
-    private static final String ISSUER_URL_PART = "&issuer=Apollo Wallet";
+    private static final String ISSUER_URL_PART = "%26issuer%3DApolloWallet";
     private static final int SECRET_LENGTH = 32;
 
     private TwoFactorAuthRepository repository;
@@ -58,12 +58,12 @@ public class TwoFactorAuthServiceImpl implements TwoFactorAuthService {
     }
 
     private String getQrCodeUrl(String rsAccount, String base32Secret) {
-        String baseUrl = TimeBasedOneTimePasswordUtil.qrImageUrl(rsAccount, base32Secret);
         try {
-            return baseUrl + URLEncoder.encode(ISSUER_URL_PART, "UTF-8");
+            String baseUrl = TimeBasedOneTimePasswordUtil.qrImageUrl(URLEncoder.encode(rsAccount, "UTF-8"), base32Secret);
+            return baseUrl + ISSUER_URL_PART;
         }
         catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e.toString());
+            throw new RuntimeException(e.toString(), e);
         }
     }
 


### PR DESCRIPTION
All apple devices cannot read otpauth url if it contains whitespaces
even if whitespaces were url encoded like %20