### PR TITLE
UPnP fix: use next free port if desired mapping is already busy

### DIFF
--- a/apl-utils/src/main/java/com/apollocurrency/aplwallet/apl/util/UPnP.java
+++ b/apl-utils/src/main/java/com/apollocurrency/aplwallet/apl/util/UPnP.java
@@ -14,12 +14,12 @@
  *
  */
 
-/*
+ /*
  * Copyright © 2018-2019 Apollo Foundation
  */
-
 package com.apollocurrency.aplwallet.apl.util;
 
+import java.io.IOException;
 import org.bitlet.weupnp.GatewayDevice;
 import org.bitlet.weupnp.GatewayDiscover;
 import org.slf4j.Logger;
@@ -28,87 +28,128 @@ import java.net.InetAddress;
 import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import javax.xml.parsers.ParserConfigurationException;
+import org.bitlet.weupnp.PortMappingEntry;
 
 import static org.slf4j.LoggerFactory.getLogger;
+import org.xml.sax.SAXException;
 
 /**
  * Forward ports using the UPnP protocol.
  */
 @Singleton
 public class UPnP {
-    private static final Logger LOG = getLogger(UPnP.class);
 
+    private static final Logger LOG = getLogger(UPnP.class);
+    public static final int MAX_PORTS_TO_TRY=999;
     private boolean isShutdown = false;
 
-    /** UPnP gateway device */
+    /**
+     * UPnP gateway device
+     */
     private GatewayDevice gateway = null;
 
-    /** Local address */
-    private  InetAddress localAddress;
+    /**
+     * Local address
+     */
+    private InetAddress localAddress;
 
-    /** External address */
+    /**
+     * External address
+     */
     private InetAddress externalAddress;
-    
-    public static int TIMEOUT=1500; //1,5 secons
-    private boolean inited=false;
 
+    public static int TIMEOUT = 1500; //1,5 secons
+    private boolean inited = false;
 
-    
 //TODO: Inject with properties    
-    @Inject  
+    @Inject
     public UPnP() {
     }
-    public boolean isInited(){
+
+    public boolean isInited() {
         return inited;
     }
+
+    public int getFreePort(int desiredExternalPort) throws IOException, SAXException {
+        int port = desiredExternalPort;
+        PortMappingEntry portMappingEntry = new PortMappingEntry();
+        boolean busy = true;
+        int count =0;
+        while(busy){
+         busy = gateway.getSpecificPortMappingEntry(port, "TCP", portMappingEntry);
+         if(busy){
+             port++;
+             count++;
+             if(count>MAX_PORTS_TO_TRY){
+                 port=-1;
+                 break;
+             }
+         }
+        }
+        return port;
+    }
+
     /**
      * Add a port to the UPnP mapping
      *
-     * @param   port                Port to add
+     * @param localPort Port to add
+     * @param description Description of port mapping
+     * @return assigned external port number or -1 if no success
      */
-    public synchronized void addPort(int port) {
+    public synchronized int addPort(int localPort, String description) {
+        int externalPort = -1;
         //
         // Ignore the request if we didn't find a gateway device
         //
-        if (gateway == null)
-            return;
+        if (gateway == null) {
+            return externalPort;
+        }
         //
         // Forward the port
         //
         try {
-            if (gateway.addPortMapping(port, port, localAddress.getHostAddress(), "TCP",
-                                       "Apollo")) {
-                LOG.debug("Mapped port [" + externalAddress.getHostAddress() + "]:" + port);
-            } else {
-                LOG.debug("Unable to map port " + port);
+            Integer extPortRQ = getFreePort(localPort);
+            if (extPortRQ < 0) {
+                return externalPort;
             }
-        } catch (Exception exc) {
-            LOG.error("Unable to map port " + port + ": " + exc.toString());
+
+            if (gateway.addPortMapping(extPortRQ, localPort, localAddress.getHostAddress(), "TCP",
+                    "Apollo(" + localAddress.getHostAddress() + "): " + description)) {
+                LOG.debug("Mapped port [" + externalAddress.getHostAddress() + "]:" + localPort
+                        + " to: " + externalAddress.getHostAddress() + ":" + extPortRQ.toString());
+                externalPort = extPortRQ;
+            } else {
+                LOG.debug("Unable to map port " + localPort);
+            }
+        } catch (IOException | SAXException exc) {
+            LOG.error("Unable to map port " + localPort + ": " + exc.toString());
         }
+        return externalPort;
     }
 
     /**
      * Delete a port from the UPnP mapping
      *
-     * @param   port                Port to delete
+     * @param externalPort EXTERNAL port to delete
      */
-    public synchronized void deletePort(int port) {
+    public synchronized void deletePort(int externalPort) {
 
         try {
-            if (gateway != null && gateway.deletePortMapping(port, "TCP")) {
-                LOG.debug("Mapping deleted for port " + port);
+            if (gateway != null && gateway.deletePortMapping(externalPort, "TCP")) {
+                LOG.debug("Mapping deleted for port " + externalPort);
             } else {
-                LOG.debug("Unable to delete mapping for port " + port);
+                LOG.debug("Unable to delete mapping for port " + externalPort);
             }
-        } catch (Exception exc) {
-            LOG.error("Unable to delete mapping for port " + port + ": " + exc.toString());
+        } catch (IOException | SAXException exc) {
+            LOG.error("Unable to delete mapping for port " + externalPort + ": " + exc.toString());
         }
     }
 
     /**
      * Return the local address
      *
-     * @return                      Local address or null if the address is not available
+     * @return Local address or null if the address is not available
      */
     public synchronized InetAddress getLocalAddress() {
         return localAddress;
@@ -117,7 +158,7 @@ public class UPnP {
     /**
      * Return the external address
      *
-     * @return  External address or null if the address is not available
+     * @return External address or null if the address is not available
      */
     public synchronized InetAddress getExternalAddress() {
         //TODO: set externalAddress from properties if we unable to do UPnP
@@ -132,9 +173,9 @@ public class UPnP {
         //
         // Discover the gateway devices on the local network
         //
-        inited=true;
+        inited = true;
         try {
-            
+
             LOG.info("Looking for UPnP gateway device...");
             GatewayDevice.setHttpReadTimeout(TIMEOUT);
             GatewayDiscover discover = new GatewayDiscover();
@@ -143,8 +184,8 @@ public class UPnP {
             if (gatewayMap == null || gatewayMap.isEmpty()) {
                 LOG.debug("There are no UPnP gateway devices");
             } else {
-                gatewayMap.forEach((addr, device) ->
-                        LOG.debug("UPnP gateway device found on " + addr.getHostAddress()));
+                gatewayMap.forEach((addr, device)
+                        -> LOG.debug("UPnP gateway device found on " + addr.getHostAddress()));
                 gateway = discover.getValidGateway();
                 if (gateway == null) {
                     LOG.debug("There is no connected UPnP gateway device");
@@ -155,7 +196,7 @@ public class UPnP {
                     LOG.info("External IP address is " + externalAddress.getHostAddress());
                 }
             }
-        } catch (Exception exc) {
+        } catch (IOException | ParserConfigurationException | SAXException exc) {
             LOG.error("Unable to discover UPnP gateway devices: " + exc.toString());
         }
         AppStatus.getInstance().update("UPnP initialization done.");


### PR DESCRIPTION
This is small fix of UPnP only. New code checks whenever required port is free and if it is free, uses it. If port is already busy it increments number an tries again. This patch fixes at least work of Apollo with UPnP routers. Now multiple Apollo instances do not "fight" for the same port. The same with API.
This patch does not fix P2P transport and announcements because old code uses IP address only. So full fix will be added to "feature/APL-540-node-id" where P2P transport is already refactored.