### PR TITLE
APL-876 fix exception eating and missing error display on UI

### DIFF
--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/http/post/CreateTransaction.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/http/post/CreateTransaction.java
@@ -114,11 +114,8 @@ public abstract class CreateTransaction extends AbstractAPIRequestHandler {
 
         Transaction transaction;
         JSONObject response = new JSONObject();
-        try {
-            transaction = createTransaction(createTransactionRequest);
-        } catch (AplException.ValidationException e) {
-            return e.getJsonResponce();
-        }
+//do not eat exception here, it is used for error message displying in UI        
+        transaction = createTransaction(createTransactionRequest);
 
         JSONObject transactionJSON = JSONData.unconfirmedTransaction(transaction);
         response.put("transactionJSON", transactionJSON);


### PR DESCRIPTION
This chfnge fixes exceptions in UI API processing. These exception are being caught in APISErvlet code and error message for UI is formed.
So if you want to catch some  APLException instance you should put error in json of responce.
This fix may affect some work done after Aug 2, 2019 so please verify your code