### PR TITLE
APL-834 cache for blockIndex 

### DIFF
--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/cache/BlockIndexCacheConfig.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/cache/BlockIndexCacheConfig.java
@@ -16,8 +16,8 @@ public class BlockIndexCacheConfig extends CacheConfigurator {
 
     public BlockIndexCacheConfig(int priority) {
         super(BLOCK_INDEX_CACHE_NAME, InMemoryCacheManager.newCalc()
-                .addAggregation(LONG_SIZE)
-                .addAggregation(INT_SIZE)
+                .addLongPrimitive()
+                .addInt()
                 .calc(),
                 priority);
     }

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/db/dao/BlockIndexDao.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/db/dao/BlockIndexDao.java
@@ -77,7 +77,7 @@ public interface BlockIndexDao {
 
     @Transactional
     @SqlUpdate("DELETE FROM block_index where block_id =:blockId")
-    int hardBlockIndex(@BindBean BlockIndex blockIndex);
+    int hardDeleteBlockIndex(@BindBean BlockIndex blockIndex);
 
     @Transactional
     @SqlUpdate("DELETE FROM block_index")

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/db/dao/model/BlockIndex.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/db/dao/model/BlockIndex.java
@@ -1,54 +1,24 @@
 package com.apollocurrency.aplwallet.apl.core.db.dao.model;
 
-import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * Block global secondary index entity.
  */
+@Getter @Setter
+@EqualsAndHashCode
+@AllArgsConstructor
+@NoArgsConstructor
 public class BlockIndex {
-    private Long blockId;
-    private Integer blockHeight;
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        BlockIndex that = (BlockIndex) o;
-        return Objects.equals(blockId, that.blockId) &&
-                Objects.equals(blockHeight, that.blockHeight);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(blockId, blockHeight);
-    }
+    private long blockId;
+    private int blockHeight;
 
     public BlockIndex copy() {
         return new BlockIndex(blockId, blockHeight);
-    }
-
-    public BlockIndex() {
-    }
-
-    public BlockIndex(Long blockId, Integer blockHeight) {
-        this.blockId = blockId;
-        this.blockHeight = blockHeight;
-    }
-
-    public Long getBlockId() {
-        return blockId;
-    }
-
-    public void setBlockId(Long blockId) {
-        this.blockId = blockId;
-    }
-
-    public Integer getBlockHeight() {
-        return blockHeight;
-    }
-
-    public void setBlockHeight(Integer blockHeight) {
-        this.blockHeight = blockHeight;
     }
 
     public static ShardBuilder builder() {
@@ -56,18 +26,18 @@ public class BlockIndex {
     }
 
     public static final class ShardBuilder {
-        private Long blockId;
-        private Integer blockHeight;
+        private long blockId;
+        private int blockHeight;
 
         private ShardBuilder() {
         }
 
-        public ShardBuilder blockId(Long blockId) {
+        public ShardBuilder blockId(long blockId) {
             this.blockId = blockId;
             return this;
         }
 
-        public ShardBuilder blockHeight(Integer blockHeight) {
+        public ShardBuilder blockHeight(int blockHeight) {
             this.blockHeight = blockHeight;
             return this;
         }

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/db/dao/model/BlockIndex.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/db/dao/model/BlockIndex.java
@@ -1,6 +1,7 @@
 package com.apollocurrency.aplwallet.apl.core.db.dao.model;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,37 +14,12 @@ import lombok.Setter;
 @EqualsAndHashCode
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class BlockIndex {
     private long blockId;
     private int blockHeight;
 
     public BlockIndex copy() {
         return new BlockIndex(blockId, blockHeight);
-    }
-
-    public static ShardBuilder builder() {
-        return new ShardBuilder();
-    }
-
-    public static final class ShardBuilder {
-        private long blockId;
-        private int blockHeight;
-
-        private ShardBuilder() {
-        }
-
-        public ShardBuilder blockId(long blockId) {
-            this.blockId = blockId;
-            return this;
-        }
-
-        public ShardBuilder blockHeight(int blockHeight) {
-            this.blockHeight = blockHeight;
-            return this;
-        }
-
-        public BlockIndex build() {
-            return new BlockIndex(blockId, blockHeight);
-        }
     }
 }

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/shard/BlockIndexService.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/shard/BlockIndexService.java
@@ -3,114 +3,22 @@
  */
 package com.apollocurrency.aplwallet.apl.core.shard;
 
-import static com.apollocurrency.aplwallet.apl.core.cache.BlockIndexCacheConfig.BLOCK_INDEX_CACHE_NAME;
-import com.apollocurrency.aplwallet.apl.core.db.dao.BlockIndexDao;
 import com.apollocurrency.aplwallet.apl.core.db.dao.model.BlockIndex;
-import com.apollocurrency.aplwallet.apl.util.cache.CacheProducer;
-import com.apollocurrency.aplwallet.apl.util.cache.CacheType;
-import com.google.common.cache.Cache;
+
 import java.util.List;
-import javax.inject.Inject;
-import javax.inject.Singleton;
 
-/**
- * Block finding service that uses block_index table via BlockIndexDao This
- * class is wrapper of DAO with managed cache
- * TODO: profile this class and optimize caching
- * @author alukin@gmail.com
- */
-@Singleton
-public class BlockIndexService {
+public interface BlockIndexService{
+    BlockIndex getByBlockId(long blockId);
 
-    private final BlockIndexDao blockIndexDao;
-    
-    
-    private final Cache<Long, BlockIndex> blockIndexCache;
+    Long getShardIdByBlockId(long blockId);
 
-    @Inject
-    public BlockIndexService(BlockIndexDao blockIndexDao,
-            @CacheProducer
-            @CacheType(BLOCK_INDEX_CACHE_NAME)                    
-            Cache<Long, BlockIndex> blockIndexCache
-    ) {
-        this.blockIndexDao = blockIndexDao;
-        this.blockIndexCache = blockIndexCache;
-    }
+    BlockIndex getByBlockHeight(int blockHeight);
 
-    public BlockIndex getByBlockId(long blockId) {
-        BlockIndex res=null;
-        if(blockIndexCache!=null){
-            res = blockIndexCache.getIfPresent(blockId);
-        }
-        if(res==null){
-            res = blockIndexDao.getByBlockId(blockId);
-            if(blockIndexCache!=null && res!=null){
-                blockIndexCache.put(blockId, res);
-            }
-        }
-        return res;
-    }
+    Long getShardIdByBlockHeight(int blockHeight);
 
-    public Long getShardIdByBlockId(long blockId) {
-        Long res = blockIndexDao.getShardIdByBlockId(blockId);
-        return res;
-    }
+    Integer getHeight(long id);
 
-    public BlockIndex getByBlockHeight(int blockHeight) {
-        BlockIndex res = blockIndexDao.getByBlockHeight(blockHeight);
-        return res;
-    }
+    List<Long> getBlockIdsAfter(int height, int limit);
 
-    public Long getShardIdByBlockHeight(int blockHeight) {
-        Long res = blockIndexDao.getShardIdByBlockHeight(blockHeight);
-        return res;
-    }
-
-    public Integer getHeight(long id) {
-        Integer res = blockIndexDao.getHeight(id);
-        return res;
-    }
-
-    public List<BlockIndex> getAllBlockIndex() {
-        return blockIndexDao.getAllBlockIndex();
-    }
-
-    public BlockIndex getLast() {
-        BlockIndex res = blockIndexDao.getLast();
-        return res;
-    }
-
-    public Integer getLastHeight() {
-        return blockIndexDao.getLastHeight();
-    }
-
-    public List<Long> getBlockIdsAfter(int height, int limit) {
-        return blockIndexDao.getBlockIdsAfter(height, limit);
-    }
-
-    public int count() {
-        return blockIndexDao.count();
-    }
-
-    public long countBlockIndexByShard(long shardId) {
-        return blockIndexDao.countBlockIndexByShard(shardId);
-    }
-
-    public int saveBlockIndex(BlockIndex blockIndex) {
-        return blockIndexDao.saveBlockIndex(blockIndex);
-    }
-
-    public int updateBlockIndex(BlockIndex blockIndex) {
-        return blockIndexDao.updateBlockIndex(blockIndex);
-    }
-
-    public int hardBlockIndex(BlockIndex blockIndex) {
-       return blockIndexDao.hardBlockIndex(blockIndex);
-    }
-
-    public int hardDeleteAllBlockIndex() {
-        return blockIndexDao.hardDeleteAllBlockIndex();
-    }
-  
-
+    int hardDeleteAllBlockIndex();
 }

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/shard/BlockIndexServiceImpl.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/shard/BlockIndexServiceImpl.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c)  2018-2019. Apollo Foundation.
+ */
+
+package com.apollocurrency.aplwallet.apl.core.shard;
+
+import com.apollocurrency.aplwallet.apl.core.db.dao.BlockIndexDao;
+import com.apollocurrency.aplwallet.apl.core.db.dao.model.BlockIndex;
+import com.apollocurrency.aplwallet.apl.util.cache.CacheProducer;
+import com.apollocurrency.aplwallet.apl.util.cache.CacheType;
+import com.google.common.cache.Cache;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.List;
+
+import static com.apollocurrency.aplwallet.apl.core.cache.BlockIndexCacheConfig.BLOCK_INDEX_CACHE_NAME;
+
+/**
+ * Block finding service that uses block_index table via BlockIndexDao This
+ * class is wrapper of DAO with managed cache
+ * @author alukin@gmail.com
+ */
+@Singleton
+public class BlockIndexServiceImpl  implements BlockIndexService {
+
+    private final BlockIndexDao blockIndexDao;
+    private final Cache<Long, BlockIndex> blockIndexCache;
+
+    @Inject
+    public BlockIndexServiceImpl(BlockIndexDao blockIndexDao,
+                             @CacheProducer
+                             @CacheType(BLOCK_INDEX_CACHE_NAME)
+                                     Cache<Long, BlockIndex> blockIndexCache
+    ) {
+        this.blockIndexDao = blockIndexDao;
+        this.blockIndexCache = blockIndexCache;
+    }
+
+    @Override
+    public BlockIndex getByBlockId(long blockId) {
+        BlockIndex res=null;
+        if(blockIndexCache!=null){
+            res = blockIndexCache.getIfPresent(blockId);
+        }
+        if(res==null){
+            res = blockIndexDao.getByBlockId(blockId);
+            if(blockIndexCache!=null && res!=null){
+                blockIndexCache.put(blockId, res);
+            }
+        }
+        return res;
+    }
+
+    @Override
+    public Long getShardIdByBlockId(long blockId) {
+        Long res = blockIndexDao.getShardIdByBlockId(blockId);
+        return res;
+    }
+
+    @Override
+    public BlockIndex getByBlockHeight(int blockHeight) {
+        BlockIndex res = blockIndexDao.getByBlockHeight(blockHeight);
+        return res;
+    }
+
+    @Override
+    public Long getShardIdByBlockHeight(int blockHeight) {
+        Long res = blockIndexDao.getShardIdByBlockHeight(blockHeight);
+        return res;
+    }
+
+    @Override
+    public Integer getHeight(long id) {
+        BlockIndex blockIndex = getByBlockId(id);
+        if (blockIndex != null){
+            return blockIndex.getBlockHeight();
+        }
+        return null;
+    }
+
+    @Override
+    public List<Long> getBlockIdsAfter(int height, int limit) {
+        return blockIndexDao.getBlockIdsAfter(height, limit);
+    }
+
+    @Override
+    public int hardDeleteAllBlockIndex() {
+        if(blockIndexCache!=null){
+            blockIndexCache.cleanUp();
+        }
+        return blockIndexDao.hardDeleteAllBlockIndex();
+    }
+
+}

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/app/BlockchainTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/app/BlockchainTest.java
@@ -14,6 +14,7 @@ import com.apollocurrency.aplwallet.apl.core.message.PrunableMessageService;
 import com.apollocurrency.aplwallet.apl.core.phasing.PhasingPollService;
 import com.apollocurrency.aplwallet.apl.core.phasing.TransactionDbInfo;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.core.transaction.PrunableTransaction;
 import com.apollocurrency.aplwallet.apl.crypto.Convert;
 import com.apollocurrency.aplwallet.apl.data.BlockTestData;
@@ -93,7 +94,7 @@ class BlockchainTest {
     @WeldSetup
     public WeldInitiator weld = WeldInitiator.from(TransactionDaoImpl.class, BlockchainImpl.class, BlockDaoImpl.class,
             TransactionIndexDao.class, DaoConfig.class,
-            BlockIndexService.class, NullCacheProducerForTests.class)
+            BlockIndexServiceImpl.class, NullCacheProducerForTests.class)
             .addBeans(MockBean.of(blockchainConfig, BlockchainConfig.class))
             .addBeans(MockBean.of(propertiesHolder, PropertiesHolder.class))
             .addBeans(MockBean.of(timeService, TimeService.class))

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/app/GenesisImporterTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/app/GenesisImporterTest.java
@@ -25,6 +25,7 @@ import com.apollocurrency.aplwallet.apl.core.db.fulltext.FullTextConfigImpl;
 import com.apollocurrency.aplwallet.apl.core.db.fulltext.FullTextSearchEngine;
 import com.apollocurrency.aplwallet.apl.core.db.fulltext.FullTextSearchService;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.crypto.Convert;
 import com.apollocurrency.aplwallet.apl.data.BalancesPublicKeysTestData;
 import com.apollocurrency.aplwallet.apl.data.DbTestData;
@@ -94,7 +95,7 @@ class GenesisImporterTest {
             .addBeans(MockBean.of(extension.getFtl(), FullTextSearchService.class))
             .addBeans(MockBean.of(aplAppStatus, AplAppStatus.class))
             .addBeans(MockBean.of(genesisImporterProducer, GenesisImporterProducer.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .build();
 
     private GenesisImporter genesisImporter;

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/db/ReferencedTransactionServiceTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/db/ReferencedTransactionServiceTest.java
@@ -23,6 +23,7 @@ import com.apollocurrency.aplwallet.apl.core.message.PrunableMessageService;
 import com.apollocurrency.aplwallet.apl.core.message.PrunableMessageServiceImpl;
 import com.apollocurrency.aplwallet.apl.core.phasing.PhasingPollService;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.data.DbTestData;
 import com.apollocurrency.aplwallet.apl.data.TransactionTestData;
 import com.apollocurrency.aplwallet.apl.extension.DbExtension;
@@ -73,7 +74,7 @@ public class ReferencedTransactionServiceTest {
             .addBeans(MockBean.of(blockchainConfig, BlockchainConfig.class))
             .addBeans(MockBean.of(mock(TransactionProcessor.class), TransactionProcessor.class))
             .addBeans(MockBean.of(mock(PhasingPollService.class), PhasingPollService.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .addBeans(MockBean.of(mock(PrunableMessageService.class), PrunableMessageService.class, PrunableMessageServiceImpl.class))
             .addBeans(MockBean.of(mock(NtpTime.class), NtpTime.class))
             .build();

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/db/dao/BlockIndexDaoTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/db/dao/BlockIndexDaoTest.java
@@ -90,7 +90,7 @@ public class BlockIndexDaoTest {
     void testGetShardIdByHeight() {
         Long height = blockIndexDao.getShardIdByBlockHeight(BLOCK_INDEX_2.getBlockHeight());
         assertNotNull(height);
-        assertEquals(BLOCK_INDEX_2.getBlockHeight().longValue(), height.longValue());
+        assertEquals(BLOCK_INDEX_2.getBlockHeight(), height.intValue());
     }
 
     @Test
@@ -197,7 +197,7 @@ public class BlockIndexDaoTest {
 
     @Test
     void testDelete() {
-        int deleteCount = blockIndexDao.hardBlockIndex(BLOCK_INDEX_1);
+        int deleteCount = blockIndexDao.hardDeleteBlockIndex(BLOCK_INDEX_1);
         assertEquals(1, deleteCount);
         assertEquals(Arrays.asList(BLOCK_INDEX_2, BLOCK_INDEX_0), blockIndexDao.getAllBlockIndex());
     }

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/db/dao/ReferencedTransactionDaoTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/db/dao/ReferencedTransactionDaoTest.java
@@ -44,6 +44,7 @@ import com.apollocurrency.aplwallet.apl.core.phasing.dao.PhasingPollTable;
 import com.apollocurrency.aplwallet.apl.core.phasing.dao.PhasingPollVoterTable;
 import com.apollocurrency.aplwallet.apl.core.phasing.dao.PhasingVoteTable;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.data.TransactionTestData;
 import com.apollocurrency.aplwallet.apl.extension.DbExtension;
 import com.apollocurrency.aplwallet.apl.util.NtpTime;
@@ -78,7 +79,7 @@ class ReferencedTransactionDaoTest {
             .addBeans(MockBean.of(extension.getDatabaseManager().getJdbiHandleFactory(), JdbiHandleFactory.class))
             .addBeans(MockBean.of(mock(TransactionProcessor.class), TransactionProcessor.class))
             .addBeans(MockBean.of(mock(NtpTime.class), NtpTime.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .addBeans(MockBean.of(mock(PrunableMessageService.class), PrunableMessageService.class, PrunableMessageServiceImpl.class))
             .build();
 

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/db/dao/ShardDaoTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/db/dao/ShardDaoTest.java
@@ -18,6 +18,7 @@ import com.apollocurrency.aplwallet.apl.core.db.cdi.transaction.JdbiHandleFactor
 import com.apollocurrency.aplwallet.apl.core.db.dao.model.Shard;
 import com.apollocurrency.aplwallet.apl.core.phasing.PhasingPollService;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.extension.DbExtension;
 import com.apollocurrency.aplwallet.apl.util.NtpTime;
 import com.apollocurrency.aplwallet.apl.util.injectable.PropertiesHolder;
@@ -61,7 +62,7 @@ class ShardDaoTest {
             .addBeans(MockBean.of(extension.getDatabaseManager().getJdbiHandleFactory(), JdbiHandleFactory.class))
             .addBeans(MockBean.of(extension.getDatabaseManager(), DatabaseManager.class))
             .addBeans(MockBean.of(extension.getDatabaseManager().getJdbi(), Jdbi.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .build();
 
     @Inject

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/db/dao/ShardRecoveryDaoTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/db/dao/ShardRecoveryDaoTest.java
@@ -17,6 +17,7 @@ import com.apollocurrency.aplwallet.apl.core.db.DerivedDbTablesRegistryImpl;
 import com.apollocurrency.aplwallet.apl.core.db.cdi.transaction.JdbiHandleFactory;
 import com.apollocurrency.aplwallet.apl.core.db.dao.model.ShardRecovery;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.core.shard.MigrateState;
 import com.apollocurrency.aplwallet.apl.extension.DbExtension;
 import com.apollocurrency.aplwallet.apl.util.NtpTime;
@@ -53,7 +54,7 @@ class ShardRecoveryDaoTest {
             .addBeans(MockBean.of(extension.getDatabaseManager(), DatabaseManager.class))
             .addBeans(MockBean.of(extension.getDatabaseManager().getJdbiHandleFactory(), JdbiHandleFactory.class))
             .addBeans(MockBean.of(extension.getDatabaseManager().getJdbi(), Jdbi.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .build();
 
     @Inject

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/db/dao/TransactionIndexDaoTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/db/dao/TransactionIndexDaoTest.java
@@ -23,6 +23,7 @@ import com.apollocurrency.aplwallet.apl.core.db.cdi.transaction.JdbiHandleFactor
 import com.apollocurrency.aplwallet.apl.core.db.dao.model.TransactionIndex;
 import com.apollocurrency.aplwallet.apl.core.phasing.PhasingPollService;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.data.IndexTestData;
 import com.apollocurrency.aplwallet.apl.extension.DbExtension;
 import com.apollocurrency.aplwallet.apl.util.NtpTime;
@@ -56,7 +57,7 @@ public class TransactionIndexDaoTest {
             .addBeans(MockBean.of(dbExtension.getDatabaseManager().getJdbi(), Jdbi.class))
             .addBeans(MockBean.of(dbExtension.getDatabaseManager().getJdbiHandleFactory(), JdbiHandleFactory.class))
             .addBeans(MockBean.of(dbExtension.getDatabaseManager(), DatabaseManager.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .build();
 
     @Inject

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/db/derived/DerivedDbTableListingTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/db/derived/DerivedDbTableListingTest.java
@@ -54,6 +54,7 @@ import com.apollocurrency.aplwallet.apl.core.phasing.dao.PhasingPollTable;
 import com.apollocurrency.aplwallet.apl.core.phasing.dao.PhasingPollVoterTable;
 import com.apollocurrency.aplwallet.apl.core.phasing.dao.PhasingVoteTable;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.core.tagged.TaggedDataServiceImpl;
 import com.apollocurrency.aplwallet.apl.core.tagged.dao.DataTagDao;
 import com.apollocurrency.aplwallet.apl.core.tagged.dao.TaggedDataDao;
@@ -135,7 +136,7 @@ class DerivedDbTableListingTest {
             .addBeans(MockBean.of(mock(BlockchainProcessor.class), BlockchainProcessorImpl.class, BlockchainProcessor.class))
             .addBeans(MockBean.of(keyStore, KeyStoreService.class))
             .addBeans(MockBean.of(blockchainConfig, BlockchainConfig.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .build();
 
     @Inject

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/db/fulltext/FullTextSearchServiceTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/db/fulltext/FullTextSearchServiceTest.java
@@ -15,6 +15,7 @@ import com.apollocurrency.aplwallet.apl.core.db.DerivedDbTablesRegistryImpl;
 import com.apollocurrency.aplwallet.apl.core.db.KeyFactoryProducer;
 import com.apollocurrency.aplwallet.apl.core.db.cdi.transaction.JdbiHandleFactory;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.core.tagged.TaggedDataServiceImpl;
 import com.apollocurrency.aplwallet.apl.core.tagged.dao.DataTagDao;
 import com.apollocurrency.aplwallet.apl.core.tagged.dao.TaggedDataDao;
@@ -62,7 +63,7 @@ class FullTextSearchServiceTest {
             .addBeans(MockBean.of(extension.getDatabaseManager().getJdbiHandleFactory(), JdbiHandleFactory.class))
             .addBeans(MockBean.of(extension.getLuceneFullTextSearchEngine(), FullTextSearchEngine.class))
             .addBeans(MockBean.of(extension.getFtl(), FullTextSearchService.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .build();
 
     @Inject

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/dgs/dao/DGSFeedbackTableTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/dgs/dao/DGSFeedbackTableTest.java
@@ -26,6 +26,7 @@ import com.apollocurrency.aplwallet.apl.core.dgs.model.DGSFeedback;
 import com.apollocurrency.aplwallet.apl.core.message.PrunableMessageService;
 import com.apollocurrency.aplwallet.apl.core.phasing.PhasingPollService;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.data.DGSTestData;
 import com.apollocurrency.aplwallet.apl.util.NtpTime;
 import com.apollocurrency.aplwallet.apl.util.injectable.PropertiesHolder;
@@ -57,7 +58,7 @@ public class DGSFeedbackTableTest extends VersionedValuesDbTableTest<DGSFeedback
             .addBeans(MockBean.of(mock(NtpTime.class), NtpTime.class))
             .addBeans(MockBean.of(mock(PrunableMessageService.class), PrunableMessageService.class))
             .addBeans(MockBean.of(mock(BlockchainProcessor.class), BlockchainProcessor.class, BlockchainProcessorImpl.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .build();
     @Inject
     DGSFeedbackTable table;

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/dgs/dao/DGSGoodsTableTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/dgs/dao/DGSGoodsTableTest.java
@@ -28,6 +28,7 @@ import com.apollocurrency.aplwallet.apl.core.dgs.model.DGSGoods;
 import com.apollocurrency.aplwallet.apl.core.message.PrunableMessageService;
 import com.apollocurrency.aplwallet.apl.core.phasing.PhasingPollService;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.data.DGSTestData;
 import com.apollocurrency.aplwallet.apl.util.NtpTime;
 import com.apollocurrency.aplwallet.apl.util.injectable.PropertiesHolder;
@@ -61,7 +62,7 @@ public class DGSGoodsTableTest extends VersionedEntityDbTableTest<DGSGoods> {
             .addBeans(MockBean.of(mock(NtpTime.class), NtpTime.class))
             .addBeans(MockBean.of(mock(PrunableMessageService.class), PrunableMessageService.class))
             .addBeans(MockBean.of(mock(BlockchainProcessor.class), BlockchainProcessor.class, BlockchainProcessorImpl.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .build();
     @Inject
     DGSGoodsTable table;

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/dgs/dao/DGSPublicFeedbackTableTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/dgs/dao/DGSPublicFeedbackTableTest.java
@@ -28,6 +28,7 @@ import com.apollocurrency.aplwallet.apl.core.dgs.model.DGSPublicFeedback;
 import com.apollocurrency.aplwallet.apl.core.message.PrunableMessageService;
 import com.apollocurrency.aplwallet.apl.core.phasing.PhasingPollService;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.data.DGSTestData;
 import com.apollocurrency.aplwallet.apl.util.NtpTime;
 import com.apollocurrency.aplwallet.apl.util.injectable.PropertiesHolder;
@@ -62,7 +63,7 @@ public class DGSPublicFeedbackTableTest extends VersionedValuesDbTableTest<DGSPu
             .addBeans(MockBean.of(mock(PrunableMessageService.class), PrunableMessageService.class))
             .addBeans(MockBean.of(mock(NtpTime.class), NtpTime.class))
             .addBeans(MockBean.of(mock(BlockchainProcessor.class), BlockchainProcessor.class, BlockchainProcessorImpl.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .build();
     @Inject
     DGSPublicFeedbackTable table;

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/dgs/dao/DGSPurchaseTableTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/dgs/dao/DGSPurchaseTableTest.java
@@ -28,6 +28,7 @@ import com.apollocurrency.aplwallet.apl.core.dgs.model.DGSPurchase;
 import com.apollocurrency.aplwallet.apl.core.message.PrunableMessageService;
 import com.apollocurrency.aplwallet.apl.core.phasing.PhasingPollService;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.data.DGSTestData;
 import com.apollocurrency.aplwallet.apl.util.NtpTime;
 import com.apollocurrency.aplwallet.apl.util.injectable.PropertiesHolder;
@@ -62,7 +63,7 @@ public class DGSPurchaseTableTest extends VersionedEntityDbTableTest<DGSPurchase
             .addBeans(MockBean.of(mock(NtpTime.class), NtpTime.class))
             .addBeans(MockBean.of(mock(PrunableMessageService.class), PrunableMessageService.class))
             .addBeans(MockBean.of(mock(BlockchainProcessor.class), BlockchainProcessor.class, BlockchainProcessorImpl.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .build();
     @Inject
     DGSPurchaseTable table;

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/dgs/dao/DGSTagTableTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/dgs/dao/DGSTagTableTest.java
@@ -30,6 +30,7 @@ import com.apollocurrency.aplwallet.apl.core.dgs.model.DGSTag;
 import com.apollocurrency.aplwallet.apl.core.message.PrunableMessageService;
 import com.apollocurrency.aplwallet.apl.core.phasing.PhasingPollService;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.data.DGSTestData;
 import com.apollocurrency.aplwallet.apl.util.NtpTime;
 import com.apollocurrency.aplwallet.apl.util.injectable.PropertiesHolder;
@@ -64,7 +65,7 @@ public class DGSTagTableTest extends VersionedEntityDbTableTest<DGSTag> {
             .addBeans(MockBean.of(mock(NtpTime.class), NtpTime.class))
             .addBeans(MockBean.of(mock(PrunableMessageService.class), PrunableMessageService.class))
             .addBeans(MockBean.of(mock(BlockchainProcessor.class), BlockchainProcessor.class, BlockchainProcessorImpl.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .build();
     @Inject
     DGSTagTable table;

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/phasing/PhasingPollServiceTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/phasing/PhasingPollServiceTest.java
@@ -49,6 +49,7 @@ import com.apollocurrency.aplwallet.apl.core.phasing.model.PhasingPoll;
 import com.apollocurrency.aplwallet.apl.core.phasing.model.PhasingPollResult;
 import com.apollocurrency.aplwallet.apl.core.phasing.model.PhasingVote;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.data.BlockTestData;
 import com.apollocurrency.aplwallet.apl.data.PhasingTestData;
 import com.apollocurrency.aplwallet.apl.data.TransactionTestData;
@@ -104,7 +105,7 @@ public class PhasingPollServiceTest {
             .addBeans(MockBean.of(mock(TransactionProcessor.class), TransactionProcessor.class))
             .addBeans(MockBean.of(mock(PrunableMessageService.class), PrunableMessageService.class))
             .addBeans(MockBean.of(mock(NtpTime.class), NtpTime.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .build();
     @Inject
     PhasingPollService service;

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/phasing/dao/PhasingPollLinkedTransactionTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/phasing/dao/PhasingPollLinkedTransactionTest.java
@@ -28,6 +28,7 @@ import com.apollocurrency.aplwallet.apl.core.message.PrunableMessageService;
 import com.apollocurrency.aplwallet.apl.core.phasing.PhasingPollService;
 import com.apollocurrency.aplwallet.apl.core.phasing.model.PhasingPollLinkedTransaction;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.data.PhasingTestData;
 import com.apollocurrency.aplwallet.apl.data.TransactionTestData;
 import com.apollocurrency.aplwallet.apl.util.NtpTime;
@@ -65,7 +66,7 @@ public class PhasingPollLinkedTransactionTest extends ValuesDbTableTest<PhasingP
             .addBeans(MockBean.of(mock(PrunableMessageService.class), PrunableMessageService.class))
             .addBeans(MockBean.of(mock(TransactionProcessor.class), TransactionProcessor.class))
             .addBeans(MockBean.of(mock(NtpTime.class), NtpTime.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .build();
     @Inject
     PhasingPollLinkedTransactionTable table;

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/phasing/dao/PhasingPollTableTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/phasing/dao/PhasingPollTableTest.java
@@ -35,6 +35,7 @@ import com.apollocurrency.aplwallet.apl.core.phasing.PhasingPollService;
 import com.apollocurrency.aplwallet.apl.core.phasing.TransactionDbInfo;
 import com.apollocurrency.aplwallet.apl.core.phasing.model.PhasingPoll;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.data.BlockTestData;
 import com.apollocurrency.aplwallet.apl.data.PhasingTestData;
 import com.apollocurrency.aplwallet.apl.data.TransactionTestData;
@@ -84,7 +85,7 @@ public class PhasingPollTableTest extends EntityDbTableTest<PhasingPoll> {
             .addBeans(MockBean.of(mock(PrunableMessageService.class), PrunableMessageService.class))
             .addBeans(MockBean.of(mock(NtpTime.class), NtpTime.class))
             .addBeans(MockBean.of(mock(BlockchainProcessor.class), BlockchainProcessor.class, BlockchainProcessorImpl.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .build();
     @Inject
     Blockchain blockchain;

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/phasing/dao/PhasingPollVoterTableTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/phasing/dao/PhasingPollVoterTableTest.java
@@ -25,6 +25,7 @@ import com.apollocurrency.aplwallet.apl.core.message.PrunableMessageService;
 import com.apollocurrency.aplwallet.apl.core.phasing.PhasingPollService;
 import com.apollocurrency.aplwallet.apl.core.phasing.model.PhasingPollVoter;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.data.PhasingTestData;
 import com.apollocurrency.aplwallet.apl.data.TransactionTestData;
 import com.apollocurrency.aplwallet.apl.util.NtpTime;
@@ -60,7 +61,7 @@ public class PhasingPollVoterTableTest extends ValuesDbTableTest<PhasingPollVote
             .addBeans(MockBean.of(mock(PrunableMessageService.class), PrunableMessageService.class))
             .addBeans(MockBean.of(mock(TransactionProcessor.class), TransactionProcessor.class))
             .addBeans(MockBean.of(mock(NtpTime.class), NtpTime.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .build();
     @Inject
     PhasingPollVoterTable table;

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/phasing/dao/PhasingResultTableTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/phasing/dao/PhasingResultTableTest.java
@@ -27,6 +27,7 @@ import com.apollocurrency.aplwallet.apl.core.message.PrunableMessageService;
 import com.apollocurrency.aplwallet.apl.core.phasing.PhasingPollService;
 import com.apollocurrency.aplwallet.apl.core.phasing.model.PhasingPollResult;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.data.PhasingTestData;
 import com.apollocurrency.aplwallet.apl.data.TransactionTestData;
 import com.apollocurrency.aplwallet.apl.testutil.DbUtils;
@@ -66,7 +67,7 @@ public class PhasingResultTableTest extends EntityDbTableTest<PhasingPollResult>
             .addBeans(MockBean.of(mock(NtpTime.class), NtpTime.class))
             .addBeans(MockBean.of(mock(PhasingPollService.class), PhasingPollService.class))
             .addBeans(MockBean.of(mock(BlockchainProcessor.class), BlockchainProcessor.class, BlockchainProcessorImpl.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .build();
     @Inject
     PhasingPollResultTable table;

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/shard/ShardEngineTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/shard/ShardEngineTest.java
@@ -173,7 +173,7 @@ class ShardEngineTest {
             .addBeans(MockBean.of(zip, Zip.class))
             .addBeans(dataExportDir)
             .addBeans(MockBean.of(mock(TimeService.class), TimeService.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
 //            .addBeans(MockBean.of(baseDbProperties, DbProperties.class)) // YL  DO NOT REMOVE THAT PLEASE, it can be used for manual testing
             .build();
 

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/shard/ShardMigrationExecutorTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/shard/ShardMigrationExecutorTest.java
@@ -172,7 +172,7 @@ class ShardMigrationExecutorTest {
             .addBeans(MockBean.of(transactionProcessor, TransactionProcessorImpl.class))
             .addBeans(MockBean.of(taskDispatchManager, TaskDispatchManager.class))
             .addBeans(MockBean.of(mock(PrunableMessageService.class), PrunableMessageService.class, PrunableMessageServiceImpl.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .build();
     @Inject
     private ShardEngine shardEngine;

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/shard/hash/ShardHashCalculatorImplTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/shard/hash/ShardHashCalculatorImplTest.java
@@ -27,6 +27,7 @@ import com.apollocurrency.aplwallet.apl.core.db.dao.ShardDao;
 import com.apollocurrency.aplwallet.apl.core.message.PrunableMessageService;
 import com.apollocurrency.aplwallet.apl.core.phasing.PhasingPollService;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.crypto.Convert;
 import com.apollocurrency.aplwallet.apl.data.BlockTestData;
 import com.apollocurrency.aplwallet.apl.extension.DbExtension;
@@ -76,7 +77,7 @@ public class ShardHashCalculatorImplTest {
                     MockBean.of(mock(PrunableMessageService.class), PrunableMessageService.class),
                     MockBean.of(mock(TransactionProcessor.class), TransactionProcessor.class),
                     MockBean.of(mock(NtpTime.class), NtpTime.class),
-                    MockBean.of(mock(BlockIndexService.class), BlockIndexService.class)
+                    MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class)
             ).build();
 
     @Inject

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/shard/helper/CsvExporterTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/shard/helper/CsvExporterTest.java
@@ -66,6 +66,7 @@ import com.apollocurrency.aplwallet.apl.core.phasing.dao.PhasingPollTable;
 import com.apollocurrency.aplwallet.apl.core.phasing.dao.PhasingPollVoterTable;
 import com.apollocurrency.aplwallet.apl.core.phasing.dao.PhasingVoteTable;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.core.shard.helper.csv.CsvAbstractBase;
 import com.apollocurrency.aplwallet.apl.core.shard.helper.csv.CsvReader;
 import com.apollocurrency.aplwallet.apl.core.shard.helper.csv.CsvReaderImpl;
@@ -200,7 +201,7 @@ class CsvExporterTest {
 //            .addBeans(MockBean.of(ftlService, FullTextSearchService.class)) // prod data test
             .addBeans(MockBean.of(keyStore, KeyStoreService.class))
             .addBeans(MockBean.of(blockchainConfig, BlockchainConfig.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .build();
     @Inject
     ShardDao shardDao;

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/shard/helper/CsvImporterTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/shard/helper/CsvImporterTest.java
@@ -39,6 +39,7 @@ import com.apollocurrency.aplwallet.apl.core.phasing.dao.PhasingPollTable;
 import com.apollocurrency.aplwallet.apl.core.phasing.dao.PhasingPollVoterTable;
 import com.apollocurrency.aplwallet.apl.core.phasing.dao.PhasingVoteTable;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.core.shard.ShardConstants;
 import com.apollocurrency.aplwallet.apl.core.tagged.TaggedDataServiceImpl;
 import com.apollocurrency.aplwallet.apl.core.tagged.dao.DataTagDao;
@@ -128,7 +129,7 @@ class CsvImporterTest {
             .addBeans(MockBean.of(mock(TrimService.class), TrimService.class))
             .addBeans(MockBean.of(time, NtpTime.class))
             .addBeans(MockBean.of(blockchainConfig, BlockchainConfig.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .build();
 
     @Inject

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/shard/helper/CsvWriterReaderDerivedTablesTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/shard/helper/CsvWriterReaderDerivedTablesTest.java
@@ -60,6 +60,7 @@ import com.apollocurrency.aplwallet.apl.core.phasing.dao.PhasingPollTable;
 import com.apollocurrency.aplwallet.apl.core.phasing.dao.PhasingPollVoterTable;
 import com.apollocurrency.aplwallet.apl.core.phasing.dao.PhasingVoteTable;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.core.shard.helper.csv.CsvReader;
 import com.apollocurrency.aplwallet.apl.core.shard.helper.csv.CsvReaderImpl;
 import com.apollocurrency.aplwallet.apl.core.shard.helper.csv.CsvWriter;
@@ -161,7 +162,7 @@ class CsvWriterReaderDerivedTablesTest {
             .addBeans(MockBean.of(mock(PhasingPollService.class), PhasingPollService.class))
             .addBeans(MockBean.of(keyStore, KeyStoreService.class))
             .addBeans(MockBean.of(blockchainConfig, BlockchainConfig.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .build();
 
     @Inject

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/tagged/TaggedDataServiceTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/tagged/TaggedDataServiceTest.java
@@ -30,6 +30,7 @@ import com.apollocurrency.aplwallet.apl.core.db.fulltext.FullTextSearchService;
 import com.apollocurrency.aplwallet.apl.core.message.PrunableMessageService;
 import com.apollocurrency.aplwallet.apl.core.phasing.PhasingPollService;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.core.tagged.dao.DataTagDao;
 import com.apollocurrency.aplwallet.apl.core.tagged.dao.TaggedDataDao;
 import com.apollocurrency.aplwallet.apl.core.tagged.dao.TaggedDataExtendDao;
@@ -91,7 +92,7 @@ class TaggedDataServiceTest {
             .addBeans(MockBean.of(time, NtpTime.class))
             .addBeans(MockBean.of(extension.getLuceneFullTextSearchEngine(), FullTextSearchEngine.class))
             .addBeans(MockBean.of(extension.getFtl(), FullTextSearchService.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .build();
 
     @Inject

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/tagged/dao/DataTagDaoTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/tagged/dao/DataTagDaoTest.java
@@ -17,6 +17,7 @@ import com.apollocurrency.aplwallet.apl.core.message.PrunableMessageService;
 import com.apollocurrency.aplwallet.apl.core.message.PrunableMessageServiceImpl;
 import com.apollocurrency.aplwallet.apl.core.phasing.PhasingPollService;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.core.tagged.model.DataTag;
 import com.apollocurrency.aplwallet.apl.core.tagged.model.TaggedData;
 import com.apollocurrency.aplwallet.apl.data.TaggedTestData;
@@ -60,7 +61,7 @@ class DataTagDaoTest {
             .addBeans(MockBean.of(mock(TransactionProcessor.class), TransactionProcessor.class))
             .addBeans(MockBean.of(mock(NtpTime.class), NtpTime.class))
             .addBeans(MockBean.of(mock(PhasingPollService.class), PhasingPollService.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .addBeans(MockBean.of(mock(PrunableMessageService.class), PrunableMessageService.class, PrunableMessageServiceImpl.class))
             .build();
 

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/tagged/dao/TaggedDataTimestampDaoTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/tagged/dao/TaggedDataTimestampDaoTest.java
@@ -22,6 +22,7 @@ import com.apollocurrency.aplwallet.apl.core.message.PrunableMessageService;
 import com.apollocurrency.aplwallet.apl.core.message.PrunableMessageServiceImpl;
 import com.apollocurrency.aplwallet.apl.core.phasing.PhasingPollService;
 import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexService;
+import com.apollocurrency.aplwallet.apl.core.shard.BlockIndexServiceImpl;
 import com.apollocurrency.aplwallet.apl.core.tagged.model.TaggedDataTimestamp;
 import com.apollocurrency.aplwallet.apl.data.TaggedTestData;
 import com.apollocurrency.aplwallet.apl.data.TransactionTestData;
@@ -64,7 +65,7 @@ class TaggedDataTimestampDaoTest {
             .addBeans(MockBean.of(mock(TransactionProcessor.class), TransactionProcessor.class))
             .addBeans(MockBean.of(mock(NtpTime.class), NtpTime.class))
             .addBeans(MockBean.of(mock(PhasingPollService.class), PhasingPollService.class))
-            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class))
+            .addBeans(MockBean.of(mock(BlockIndexService.class), BlockIndexService.class, BlockIndexServiceImpl.class))
             .addBeans(MockBean.of(mock(PrunableMessageService.class), PrunableMessageService.class, PrunableMessageServiceImpl.class))
             .build();
 


### PR DESCRIPTION
the inner fields were converted to primitive in BlockIndex;
extracted interface for BlockIndexService;
added cache;
fixed tests;