### PR TITLE
Better weighting, now 1.0 for last shard with all nodes OK

### DIFF
--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/files/shards/ShardsDownloadService.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/files/shards/ShardsDownloadService.java
@@ -221,6 +221,9 @@ public class ShardsDownloadService {
         } else {
             //we have some shards available on the networks, let's decide what to do
             Map<Long,Double> shardWeights = shardInfoDownloader.getShardRelativeWeights();
+            shardWeights.keySet().forEach((k) -> {
+                log.debug("Shard: {} Weight: {}",k,shardWeights.get(k));
+            });
             for (Long shardId : sortByValue(shardWeights).keySet()) {
                 double w = shardWeights.get(shardId);
                 if(w>0){

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/rest/service/TransportInteractionWebSocket.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/rest/service/TransportInteractionWebSocket.java
@@ -51,6 +51,7 @@ public class TransportInteractionWebSocket {
     private static final Logger log = LoggerFactory.getLogger(TransportInteractionWebSocket.class);
     
     private SecureTransportStatus secureTransportStatus;
+    public static final int CONNECTION_WAIT_MS=300;
     
     // status of the transport connection
     public enum SecureTransportStatus implements Serializable {
@@ -113,10 +114,10 @@ public class TransportInteractionWebSocket {
         ClientUpgradeRequest request = new ClientUpgradeRequest();
         client.connect(this, endpointURI, request);
         log.debug("Connecting to : {} ", endpointURI);
-        awaitClose(5, TimeUnit.SECONDS);
+        awaitClose(CONNECTION_WAIT_MS, TimeUnit.MILLISECONDS);
         
         } catch (Exception ex) {
-            log.error("WS connection exception: {}",  ex.getMessage().toString());            
+            log.error("WS connection exception: ",  ex);            
         }
         
     }

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/files/shards/ShardInfoDownloaderTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/files/shards/ShardInfoDownloaderTest.java
@@ -229,7 +229,8 @@ public class ShardInfoDownloaderTest {
         downloader.processAllPeersShardingInfo();
         Map<String, ShardingInfo> result = downloader.getShardInfoByPeers();
         int size = result.size();
-        assertEquals(size,7);        
+        //one gets removed
+        assertEquals(size,6);        
     }
 
     /**


### PR DESCRIPTION
Some logging added
Smaller time for secure transport waiting (300 ms)