### PR TITLE
Do shard synchronously on trimService::init

### DIFF
--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/app/TrimService.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/app/TrimService.java
@@ -208,6 +208,10 @@ public class TrimService {
         return res;
     }
     
+    public int doTrimDerivedTablesOnHeightIgnorigLock(int height) {
+       return doTrimDerivedTablesOnHeight(height);
+    }  
+    
     @Transactional
     private int doTrimDerivedTablesOnHeight(int height) {
         log.debug("TRIM: doTrimDerivedTablesOnHeight on height={}, oneLock={}", height);

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/files/shards/ShardInfoDownloader.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/files/shards/ShardInfoDownloader.java
@@ -297,6 +297,13 @@ public class ShardInfoDownloader {
         int badPeersNumber = ( badPeers == null ? 0 : badPeers.size() );
         int noShardPeersNumber = allPeersNumber - (goodPeersNumber+badPeersNumber);
         res = (1.0*goodPeersNumber-1.0*badPeersNumber-1.0*noShardPeersNumber)/allPeersNumber;
+        log.debug("Shard: {} good: {} bad: {} no shard: {} weight: {}",shardId,goodPeersNumber,badPeersNumber,noShardPeersNumber,res);
+        if(goodPeers!=null){
+          log.debug("Good peers: {}",goodPeers.stream().map(e->e.getPeerId()+" ").reduce(String::concat));
+        }
+        if(badPeers!=null){
+          log.debug("Bad peers: {}",badPeers.stream().map(e->e.getPeerId()+" ").reduce(String::concat));            
+        }
         return res;
     }
     

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/shard/ShardEngineImpl.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/shard/ShardEngineImpl.java
@@ -500,9 +500,11 @@ public class ShardEngineImpl implements ShardEngine {
             dataSource.begin();
         }
         try {
-            trimService.waitTrimming();
-            return trimService.doTrimDerivedTablesOnHeightLocked(height);
+            //we ignore trim lock here to awoid dead-locking on cycklic trim execution
+            //because we can get called from trimService by sync event
+            return trimService.doTrimDerivedTablesOnHeightIgnorigLock(height);
         } catch (Exception e) {
+            log.error("Triming error in sharding: ",e);
             databaseManager.getDataSource().rollback(false);
             throw new RuntimeException(e);
         } finally {

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/shard/observer/ShardObserver.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/shard/observer/ShardObserver.java
@@ -41,10 +41,13 @@ public class ShardObserver {
     }
 
     public void onTrimDone(@Observes @Sync TrimData trimData) {
-//do it sync and wait result to block other trims
-       CompletableFuture<MigrateState> shardingDone = tryCreateShardAsync(trimData.getTrimHeight(), trimData.getBlockchainHeight());
+        //do it sync and wait result to block other trims
+        CompletableFuture<MigrateState> shardingDone = tryCreateShardAsync(trimData.getTrimHeight(), trimData.getBlockchainHeight());
         try {
-            shardingDone.get();
+            if (shardingDone != null) {
+                // sometimes there is no completebleFuture
+                shardingDone.get();
+            }
         } catch (InterruptedException ex) {
             log.info("Sharding interrupted", ex);
             Thread.currentThread().interrupt();

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/shard/observer/ShardObserver.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/shard/observer/ShardObserver.java
@@ -46,10 +46,10 @@ public class ShardObserver {
         try {
             shardingDone.get();
         } catch (InterruptedException ex) {
-            log.info("Sharding interrupted",ex);
+            log.info("Sharding interrupted", ex);
             Thread.currentThread().interrupt();
         } catch (ExecutionException ex) {
-            log.error("Shatding execution failed",ex);            
+            log.error("Sharding execution failed", ex);
         }
     }
 


### PR DESCRIPTION
It is attempt to fix situation when node goes down on the height near sharding height and at the same time avoid dead-locking on cyclic trim execution