### PR TITLE
Fix/apl 1196 interceptor multiple archives

### DIFF
--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/app/BlockchainProcessorImpl.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/app/BlockchainProcessorImpl.java
@@ -1143,7 +1143,7 @@ public class BlockchainProcessorImpl implements BlockchainProcessor {
             for (DerivedTableInterface table : dbTables.getDerivedTables()) {
                 long start = System.currentTimeMillis();
                 table.rollback(commonBlockHeight);
-                log.debug("rollback for table={} to commonBlockHeight={} in {} ms", table.getName(),
+                log.trace("rollback for table={} to commonBlockHeight={} in {} ms", table.getName(),
                         commonBlockHeight, System.currentTimeMillis() - start);
             }
             log.debug("Total rollback time: {} ms", System.currentTimeMillis() - rollbackStartTime);
@@ -1739,16 +1739,16 @@ public class BlockchainProcessorImpl implements BlockchainProcessor {
                 if (betterCumulativeDifficulty.equals(curCumulativeDifficulty)) {
                     return;
                 }
-                
+
                 long commonMilestoneBlockId = blockchain.getShardInitialBlock().getId();
-                
+
                 if (lookupBlockhain().getHeight() > 0) {
                     commonMilestoneBlockId = getCommonMilestoneBlockId(peer);
                 }
                 if (commonMilestoneBlockId == 0 || !peerHasMore) {
                     return;
                 }
-                
+
                 chainBlockIds = getBlockIdsAfterCommon(peer, commonMilestoneBlockId, false);
                 if (chainBlockIds.size() < 2 || !peerHasMore) {
                     if (commonMilestoneBlockId == blockchain.getShardInitialBlock().getId()) {
@@ -1757,7 +1757,7 @@ public class BlockchainProcessorImpl implements BlockchainProcessor {
                     }
                     return;
                 }
-                
+
                 final long commonBlockId = chainBlockIds.get(0);
                 final Block commonBlock = lookupBlockhain().getBlock(commonBlockId);
                 if (commonBlock == null || lookupBlockhain().getHeight() - commonBlock.getHeight() >= Constants.MAX_AUTO_ROLLBACK) {
@@ -1784,7 +1784,7 @@ public class BlockchainProcessorImpl implements BlockchainProcessor {
                     if (lookupBlockhain().getHeight() - commonBlock.getHeight() <= 10) {
                         return;
                     }
-                    
+
                     int confirmations = 0;
                     for (Peer otherPeer : connectedPublicPeers) {
                         if (confirmations >= numberOfForkConfirmations) {
@@ -1818,7 +1818,7 @@ public class BlockchainProcessorImpl implements BlockchainProcessor {
                         downloadBlockchain(otherPeer, otherPeerCommonBlock, commonBlock.getHeight());
                     }
                     log.debug("Got " + confirmations + " confirmations");
-                    
+
                     if (lookupBlockhain().getLastBlock().getId() != lastBlockId) {
                         long time = System.currentTimeMillis() - startTime;
                         totalTime += time;
@@ -1849,9 +1849,9 @@ public class BlockchainProcessorImpl implements BlockchainProcessor {
          * @return id of the first mutual block
          */
         private long getCommonMilestoneBlockId(Peer peer) {
-            
+
             String lastMilestoneBlockId = null;
-            
+
             while (true) {
                 JSONObject milestoneBlockIdsRequest = new JSONObject();
                 milestoneBlockIdsRequest.put("requestType", "getMilestoneBlockIds");
@@ -1861,7 +1861,7 @@ public class BlockchainProcessorImpl implements BlockchainProcessor {
                 } else {
                     milestoneBlockIdsRequest.put("lastMilestoneBlockId", lastMilestoneBlockId);
                 }
-                
+
                 JSONObject response;
                 try {
                     response = peer.send(JSON.prepareRequest(milestoneBlockIdsRequest), blockchainConfig.getChain().getChainId());
@@ -1898,7 +1898,7 @@ public class BlockchainProcessorImpl implements BlockchainProcessor {
                     lastMilestoneBlockId = (String) milestoneBlockId;
                 }
             }
-            
+
         }
 
         private List<Long> getBlockIdsAfterCommon(final Peer peer, final long startBlockId, final boolean countFromStart) {
@@ -2059,7 +2059,7 @@ public class BlockchainProcessorImpl implements BlockchainProcessor {
                         slowestPeer = nextBlocks.getPeer();
                     }
                 }
-                
+
             }
             if (slowestPeer != null && connectedPublicPeers.size() >= PeersService.maxNumberOfConnectedPublicPeers && chainBlockIds.size() > Constants.MAX_AUTO_ROLLBACK / 2) {
                 log.debug("Solwest peer {} took {} ms, disconnecting", slowestPeer.getHost(), maxResponseTime);
@@ -2102,15 +2102,15 @@ public class BlockchainProcessorImpl implements BlockchainProcessor {
             } finally {
                 globalSync.writeUnlock();
             }
-            
+
         }
 
         private void processFork(final Peer peer, final List<Block> forkBlocks, final Block commonBlock) {
-            
+
             BigInteger curCumulativeDifficulty = lookupBlockhain().getLastBlock().getCumulativeDifficulty();
-            
+
             List<Block> myPoppedOffBlocks = popOffToCommonBlock(commonBlock);
-            
+
             int pushedForkBlocks = 0;
             if (lookupBlockhain().getLastBlock().getId() == commonBlock.getId()) {
                 for (Block block : forkBlocks) {
@@ -2125,7 +2125,7 @@ public class BlockchainProcessorImpl implements BlockchainProcessor {
                     }
                 }
             }
-            
+
             if (pushedForkBlocks > 0 && lookupBlockhain().getLastBlock().getCumulativeDifficulty().compareTo(curCumulativeDifficulty) < 0) {
                 log.debug("Pop off caused by peer {}, blacklisting",peer.getHost());
                 peer.blacklist("Pop off");
@@ -2135,7 +2135,7 @@ public class BlockchainProcessorImpl implements BlockchainProcessor {
                     lookupTransactionProcessor().processLater(block.getOrLoadTransactions());
                 }
             }
-            
+
             if (pushedForkBlocks == 0) {
                 log.debug("Didn't accept any blocks, pushing back my previous blocks");
                 for (int i = myPoppedOffBlocks.size() - 1; i >= 0; i--) {
@@ -2153,7 +2153,7 @@ public class BlockchainProcessorImpl implements BlockchainProcessor {
                     lookupTransactionProcessor().processLater(block.getOrLoadTransactions());
                 }
             }
-            
+
         }
     }
 

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/app/TrimService.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/app/TrimService.java
@@ -232,7 +232,8 @@ public class TrimService {
                     table.trim(height);
                     dataSource.commit(false);
                     long duration = System.currentTimeMillis() - startTime;
-                    log.debug("Trim of {} took {} ms", table.getName(), duration);
+                    // do not log trim duration here, instead go to the logback config and enable trace logs for BasicDbTable class
+                    //                    log.trace("Trim of {} took {} ms", table.getName(), duration);
                     onlyTrimTime += duration;
                 } finally {
                     globalSync.readUnlock();

--- a/apl-core/src/main/resources/META-INF/beans.xml
+++ b/apl-core/src/main/resources/META-INF/beans.xml
@@ -6,7 +6,4 @@
     <decorators>
         <class>org.jboss.weld.environment.se.threading.RunnableDecorator</class>
     </decorators>
-    <interceptors>
-        <class>com.apollocurrency.aplwallet.apl.core.db.cdi.transaction.JdbiTransactionalInterceptor</class>
-    </interceptors>
 </beans>

--- a/apl-exec/src/main/java/com/apollocurrency/aplwallet/apl/exec/Apollo.java
+++ b/apl-exec/src/main/java/com/apollocurrency/aplwallet/apl/exec/Apollo.java
@@ -5,27 +5,14 @@ package com.apollocurrency.aplwallet.apl.exec;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
-import com.apollocurrency.aplwallet.api.dto.Account;
 import com.apollocurrency.aplwallet.apl.conf.ConfPlaceholder;
-import com.apollocurrency.aplwallet.apl.core.app.AplCore;
 import com.apollocurrency.aplwallet.apl.core.app.AplCoreRuntime;
 import com.apollocurrency.aplwallet.apl.core.app.service.SecureStorageService;
 import com.apollocurrency.aplwallet.apl.core.chainid.BlockchainConfig;
 import com.apollocurrency.aplwallet.apl.core.chainid.BlockchainConfigUpdater;
-import com.apollocurrency.aplwallet.apl.core.db.DatabaseManager;
-import com.apollocurrency.aplwallet.apl.core.db.DerivedTablesRegistry;
-import com.apollocurrency.aplwallet.apl.core.db.cdi.transaction.JdbiHandleFactory;
-import com.apollocurrency.aplwallet.apl.core.db.fulltext.FullTextConfig;
-import com.apollocurrency.aplwallet.apl.core.db.fulltext.FullTextTrigger;
 import com.apollocurrency.aplwallet.apl.core.migrator.MigratorUtil;
-import com.apollocurrency.aplwallet.apl.core.rest.converter.PeerConverter;
-import com.apollocurrency.aplwallet.apl.core.rest.endpoint.NodeInfoController;
-import com.apollocurrency.aplwallet.apl.core.rest.service.ServerInfoService;
-import com.apollocurrency.aplwallet.apl.core.shard.ShardEngineImpl;
 import com.apollocurrency.aplwallet.apl.core.task.TaskDispatchManager;
-import com.apollocurrency.aplwallet.apl.core.transaction.TransactionType;
 import com.apollocurrency.aplwallet.apl.udpater.intfce.UpdaterCore;
-import com.apollocurrency.aplwallet.apl.updater.core.Updater;
 import com.apollocurrency.aplwallet.apl.updater.core.UpdaterCoreImpl;
 import com.apollocurrency.aplwallet.apl.util.Constants;
 import com.apollocurrency.aplwallet.apl.util.StringUtils;
@@ -94,7 +81,7 @@ public class Apollo {
     private PropertiesHolder propertiesHolder;
     private TaskDispatchManager taskDispatchManager;
     private static AplCoreRuntime aplCoreRuntime;
-    
+
     private final static String[] VALID_LOG_LEVELS = {"ERROR", "WARN", "INFO", "DEBUG", "TRACE"};
 
     private static void setLogLevel(int logLevel) {
@@ -102,14 +89,14 @@ public class Apollo {
         String packageName = "com.apollocurrency.aplwallet.apl";
         if (logLevel >= VALID_LOG_LEVELS.length - 1) {
             logLevel = VALID_LOG_LEVELS.length - 1;
-        }   
+        }
             LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
 
             ch.qos.logback.classic.Logger logger = loggerContext.getLogger(packageName);
             System.out.println(packageName + " current logger level: " + logger.getLevel()
                     + " New level: " + VALID_LOG_LEVELS[logLevel]);
 
-            logger.setLevel(Level.toLevel(VALID_LOG_LEVELS[logLevel]));        
+            logger.setLevel(Level.toLevel(VALID_LOG_LEVELS[logLevel]));
         // otherwise we want to load usual logback.xml settings
     }
 
@@ -269,29 +256,16 @@ public class Apollo {
 
         //init CDI container
         container = AplContainer.builder().containerId("MAIN-APL-CDI")
-                .recursiveScanPackages(AplCore.class)
-                .recursiveScanPackages(PropertiesHolder.class)
-                .recursiveScanPackages(TaskDispatchManager.class)
-                .recursiveScanPackages(Updater.class)
-                .recursiveScanPackages(NodeInfoController.class)
-                .recursiveScanPackages(ServerInfoService.class)
-                .recursiveScanPackages(Account.class)
-                .recursiveScanPackages(TransactionType.class)
-                .recursiveScanPackages(FullTextTrigger.class)
-                .recursiveScanPackages(BlockchainConfig.class)
-                .recursiveScanPackages(DatabaseManager.class)
-                .recursiveScanPackages(DerivedTablesRegistry.class)
-                .recursiveScanPackages(FullTextConfig.class)
-                .recursiveScanPackages(PeerConverter.class)
-                .recursiveScanPackages(DirProvider.class)
-                .annotatedDiscoveryMode()
+            // do not use recursive scan because it violates the restriction to
+            // deploy one bean for all deployment archives
+            // Recursive scan will trigger base synthetic archive to load JdbiTransactionalInterceptor, which was already loaded by apl-core archive
+            // See https://docs.jboss.org/cdi/spec/2.0.EDR2/cdi-spec.html#se_bootstrap for more details
 // we already have it in beans.xml in core
-                .recursiveScanPackages(JdbiHandleFactory.class)
                 .annotatedDiscoveryMode()
                 //TODO:  turn it on periodically in development process to check CDI errors
                 // Enable for development only, see http://weld.cdi-spec.org/news/2015/11/10/weld-probe-jmx/
                 // run with ./bin/apl-run-jmx.sh
-                //.devMode() 
+                //.devMode()
                 .build();
         log.debug("Weld CDI container build done");
         // init config holders

--- a/apl-tools/src/main/java/com/apollocurrency/aplwallet/apl/tools/impl/heightmon/HeightMonitor.java
+++ b/apl-tools/src/main/java/com/apollocurrency/aplwallet/apl/tools/impl/heightmon/HeightMonitor.java
@@ -4,17 +4,17 @@
 
 package com.apollocurrency.aplwallet.apl.tools.impl.heightmon;
 
-import static org.slf4j.LoggerFactory.getLogger;
-
 import com.apollocurrency.aplwallet.apl.tools.impl.heightmon.model.HeightMonitorConfig;
 import com.apollocurrency.aplwallet.apl.tools.impl.heightmon.web.JettyServer;
 import com.apollocurrency.aplwallet.apl.util.cdi.AplContainer;
 import org.slf4j.Logger;
 
+import javax.enterprise.inject.spi.CDI;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import javax.enterprise.inject.spi.CDI;
+
+import static org.slf4j.LoggerFactory.getLogger;
 
 public class HeightMonitor {
     private static final Logger log = getLogger(HeightMonitor.class);
@@ -36,7 +36,7 @@ public class HeightMonitor {
         try {
             this.container =  AplContainer.builder().containerId("MAIN-APL-CDI")
                     .annotatedDiscoveryMode()
-                    .recursiveScanPackages(JettyServer.class)
+//                    .recursiveScanPackages(JettyServer.class)
                     .devMode() // enable for dev only
                     .build();
             HeightMonitorService service = CDI.current().select(HeightMonitorService.class).get();

--- a/apl-utils/src/main/java/com/apollocurrency/aplwallet/apl/util/cdi/AplContainerBuilder.java
+++ b/apl-utils/src/main/java/com/apollocurrency/aplwallet/apl/util/cdi/AplContainerBuilder.java
@@ -15,9 +15,9 @@ import java.util.stream.Collectors;
  */
 public class AplContainerBuilder {
     private static final Logger log = LoggerFactory.getLogger(AplContainerBuilder.class);
-    
+
     private boolean devMode = false;
-    
+
     private String containerId;
 
     private Boolean annotatedDiscoveryMode;
@@ -26,7 +26,7 @@ public class AplContainerBuilder {
 
     private List<Class<?>> interceptors;
 
-    private List<Class<?>> recursiveScanPackages;
+//    private List<Class<?>> recursiveScanPackages;
 
     public AplContainerBuilder containerId(String id) {
         containerId = id;
@@ -44,13 +44,13 @@ public class AplContainerBuilder {
         disableDiscovery = true;
         return this;
     }
-    
+
     public AplContainerBuilder devMode(){
         devMode=true;
         System.setProperty("org.jboss.weld.probe.jmxSupport", "true");
         return this;
     }
-        
+
     public AplContainerBuilder interceptors(Class<?>... interceptors) {
         if (interceptors != null && interceptors.length > 0) {
             this.interceptors = Arrays.stream(interceptors).collect(Collectors.toList());
@@ -58,12 +58,12 @@ public class AplContainerBuilder {
         return this;
     }
 
-    public AplContainerBuilder recursiveScanPackages(Class<?>... recursiveScanPackages) {
-        if (recursiveScanPackages != null && recursiveScanPackages.length > 0) {
-            this.recursiveScanPackages = Arrays.stream(recursiveScanPackages).collect(Collectors.toList());
-        }
-        return this;
-    }
+//    public AplContainerBuilder recursiveScanPackages(Class<?>... recursiveScanPackages) {
+//        if (recursiveScanPackages != null && recursiveScanPackages.length > 0) {
+//            this.recursiveScanPackages = Arrays.stream(recursiveScanPackages).collect(Collectors.toList());
+//        }
+//        return this;
+//    }
 
     public AplContainer build() {
         log.debug("Apollo DI container build()...");
@@ -85,14 +85,10 @@ public class AplContainerBuilder {
             interceptors.forEach(weld::addInterceptor);
         }
 
-        if (recursiveScanPackages != null && !recursiveScanPackages.isEmpty()) {
-            recursiveScanPackages.forEach(p -> weld.addPackage(true, p));
-        }
-
         if(devMode){
           weld.enableDevMode();
         }
-        
+
         WeldContainer newContainer = weld.initialize();
 
         if (newContainer.isUnsatisfied()) {

--- a/apl-utils/src/main/java/com/apollocurrency/aplwallet/apl/util/env/dirprovider/DefaultConfigDirProvider.java
+++ b/apl-utils/src/main/java/com/apollocurrency/aplwallet/apl/util/env/dirprovider/DefaultConfigDirProvider.java
@@ -34,7 +34,7 @@ public class DefaultConfigDirProvider implements ConfigDirProvider {
             this.netIndex=netIdx;
         }
     }
-    
+
     @Override
     public String getConfigDirectoryName(){
         return CONF_DIRS[netIndex];
@@ -62,6 +62,6 @@ public class DefaultConfigDirProvider implements ConfigDirProvider {
                 ? getSysConfigDirectory()
                 : getUserConfigDirectory();
         return res;
-       
+
     }
 }


### PR DESCRIPTION
This pr fixes issue with JdbiTransactionInterceptor, which is found in 2 deployment archives causing unexpected behavior
```
10:25:40.635 [main] WARN  org.jboss.weld.Bootstrap:991 - WELD-ENV-002008: Bean class com.apollocurrency.aplwallet.apl.core.db.cdi.transaction.JdbiTransactionalInterceptor found in multiple bean archives - this may result in incorrect behavior: 

WeldBeanDeploymentArchive [id=/opt/ApolloFoundation/Apollo/lib/apl-core-1.41.4.jar],

WeldBeanDeploymentArchive [id=org.jboss.weld.environment.deployment.WeldDeployment.synthetic]

```
