### PR TITLE
Fix 'nonce too low' for already created eth transactions

### DIFF
--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/eth/web3j/ComparableStaticGasProvider.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/eth/web3j/ComparableStaticGasProvider.java
@@ -28,4 +28,8 @@ public class ComparableStaticGasProvider extends StaticGasProvider {
         return Objects.hash(getGasLimit(), getGasPrice());
     }
 
+    @Override
+    public String toString() {
+        return "GasPrice:" + getGasPrice() + ",GasLimit:" + getGasLimit();
+    }
 }

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/exchange/service/DexSmartContractService.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/exchange/service/DexSmartContractService.java
@@ -10,6 +10,7 @@ import com.apollocurrency.aplwallet.apl.eth.utils.EthUtil;
 import com.apollocurrency.aplwallet.apl.eth.web3j.ComparableStaticGasProvider;
 import com.apollocurrency.aplwallet.apl.eth.web3j.DefaultRawTransactionManager;
 import com.apollocurrency.aplwallet.apl.exchange.dao.DexTransactionDao;
+import com.apollocurrency.aplwallet.apl.exchange.exception.NotValidTransactionException;
 import com.apollocurrency.aplwallet.apl.exchange.mapper.DepositedOrderDetailsMapper;
 import com.apollocurrency.aplwallet.apl.exchange.mapper.SwapDataInfoMapper;
 import com.apollocurrency.aplwallet.apl.exchange.mapper.UserEthDepositInfoMapper;
@@ -338,7 +339,13 @@ public class DexSmartContractService {
                         }
                     }
                 } else {
-                    sendRawTransaction(Numeric.toHexString(tx.getRawTransactionBytes()), waitConfirmation); // broadcast existing tx
+                    try {
+                        sendRawTransaction(Numeric.toHexString(tx.getRawTransactionBytes()), waitConfirmation); // broadcast existing tx
+                    } catch (NotValidTransactionException e) {
+                        log.info("Stored previous transaction is incorrect, removing... New will be sent.", e);
+                        dexTransactionDao.delete(tx.getDbId());
+                        txHash = null;
+                    }
                 }
             } catch (IOException e) {
                 log.error("Unable to broadcast tx or get receipt " + Numeric.toHexString(tx.getHash()), e);
@@ -355,11 +362,11 @@ public class DexSmartContractService {
         return  web3j.ethGetTransactionReceipt(hash).send().getTransactionReceipt();
     }
 
-    String sendRawTransaction(String encodedTx, boolean waitConfirmation) throws IOException {
+    String sendRawTransaction(String encodedTx, boolean waitConfirmation) throws IOException, NotValidTransactionException {
         EthSendTransaction response = web3j.ethSendRawTransaction(encodedTx).send();
         if (response != null) {
             if (response.hasError()) {
-                throw new RuntimeException(response.getError().getMessage() + ", data - " + response.getError().getData() + ", tx: " + encodedTx);
+                throw new NotValidTransactionException(response.getError().getMessage() + ", data - " + response.getError().getData() + ", tx: " + encodedTx);
             }
         } else {
             throw new RuntimeException("Unable to broadcast eth transaction, null response:  " + encodedTx);

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/exchange/service/DexSmartContractServiceTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/exchange/service/DexSmartContractServiceTest.java
@@ -364,6 +364,7 @@ class DexSmartContractServiceTest {
         String hash = service.deposit(ALICE_PASS, 100L, ALICE_ID, ALICE_ETH_ADDRESS, BigInteger.TEN, 10L, DexCurrency.ETH);
 
         assertEquals("hash", hash);
+        verify(dexTransactionDao).delete(1);
     }
 
     @Test


### PR DESCRIPTION
Fix 'nonce too low' problem for previously created but not sent eth transactions