### PR TITLE
disable Weld concurrent deployment support;

### DIFF
--- a/apl-exec/src/main/java/com/apollocurrency/aplwallet/apl/exec/Apollo.java
+++ b/apl-exec/src/main/java/com/apollocurrency/aplwallet/apl/exec/Apollo.java
@@ -18,6 +18,7 @@ import com.apollocurrency.aplwallet.apl.updater.core.UpdaterCoreImpl;
 import com.apollocurrency.aplwallet.apl.util.Constants;
 import com.apollocurrency.aplwallet.apl.util.StringUtils;
 import com.apollocurrency.aplwallet.apl.util.cdi.AplContainer;
+import com.apollocurrency.aplwallet.apl.util.cdi.AplContainerBuilder;
 import com.apollocurrency.aplwallet.apl.util.env.EnvironmentVariables;
 import com.apollocurrency.aplwallet.apl.util.env.PosixExitCodes;
 import com.apollocurrency.aplwallet.apl.util.env.RuntimeEnvironment;
@@ -255,19 +256,27 @@ public class Apollo {
             System.exit(PosixExitCodes.EX_CANTCREAT.exitCode());
         }
 
-        //init CDI container
-        container = AplContainer.builder().containerId("MAIN-APL-CDI")
+        //Configure CDI Container builder
+        AplContainerBuilder aplContainerBuilder = AplContainer.builder().containerId("MAIN-APL-CDI")
             // do not use recursive scan because it violates the restriction to
             // deploy one bean for all deployment archives
             // Recursive scan will trigger base synthetic archive to load JdbiTransactionalInterceptor, which was already loaded by apl-core archive
             // See https://docs.jboss.org/cdi/spec/2.0.EDR2/cdi-spec.html#se_bootstrap for more details
-// we already have it in beans.xml in core
-                .annotatedDiscoveryMode()
-                //TODO:  turn it on periodically in development process to check CDI errors
-                // Enable for development only, see http://weld.cdi-spec.org/news/2015/11/10/weld-probe-jmx/
-                // run with ./bin/apl-run-jmx.sh
-                //.devMode()
-                .build();
+            // we already have it in beans.xml in core
+            .annotatedDiscoveryMode();
+            //TODO:  turn it on periodically in development process to check CDI errors
+            // Enable for development only, see http://weld.cdi-spec.org/news/2015/11/10/weld-probe-jmx/
+            // run with ./bin/apl-run-jmx.sh
+            //.devMode()
+        if(args.disableWeldConcurrentDeployment) {
+            //It's very helpful when the application is stuck during the Weld Container building.
+            log.info("The concurrent deployment of Weld container is disabled.");
+            aplContainerBuilder.disableConcurrentDeployment();
+        }
+
+        //init CDI container
+        container = aplContainerBuilder.build();
+
         log.debug("Weld CDI container build done");
         // init config holders
         app.propertiesHolder = CDI.current().select(PropertiesHolder.class).get();
@@ -290,13 +299,8 @@ public class Apollo {
         try {
             // updated shutdown hook explicitly created with instances
             Runtime.getRuntime().addShutdownHook(new ShutdownHook(aplCoreRuntime));
-//            Runtime.getRuntime().addShutdownHook(new Thread(Apollo::shutdown, "ShutdownHookThread:"));
             aplCoreRuntime.addCoreAndInit();
             app.initUpdater(args.updateAttachmentFile, args.debugUpdater);
-            /*            if(unzipRes.get()!=true){
-                System.err.println("Error! WebUI is not installed!");
-            }
-             */
             if (args.startMint) {
                 aplCoreRuntime.startMinter();
             }

--- a/apl-exec/src/main/java/com/apollocurrency/aplwallet/apl/exec/CmdLineArgs.java
+++ b/apl-exec/src/main/java/com/apollocurrency/aplwallet/apl/exec/CmdLineArgs.java
@@ -9,7 +9,7 @@ import com.beust.jcommander.Parameter;
  */
 public class CmdLineArgs {
     public static int DEFAULT_DEBUG_LEVEL=2;
-    
+
     @Parameter(names = {"--debug", "-d"}, description = "Debug level [0-4] from ERROR to TRACE")
     public int debug = DEFAULT_DEBUG_LEVEL;
     @Parameter(names = {"--debug-updater", "-du"}, description = "Force updater to use debug certificates for verifying update transactions")
@@ -53,6 +53,10 @@ public class CmdLineArgs {
     public int netIdx=0;
     @Parameter(names = {"--testnet"}, help = true, description = "Connect to testent 1. Has higher priority then --net")
     public boolean isTestnet = false;
+    //---
+    @Parameter(names = {"--disable-weld-concurrent-deployment"},
+        description = "If use it, Weld doesn't use ConcurrentDeployer and ConcurrentValidator to build the container. Default value is true.")
+    public boolean disableWeldConcurrentDeployment = false;
 
     public boolean isResourceIgnored() {
         return !resourcesPath.isEmpty() || ingnoreResources;

--- a/apl-utils/src/main/java/com/apollocurrency/aplwallet/apl/util/cdi/AplContainerBuilder.java
+++ b/apl-utils/src/main/java/com/apollocurrency/aplwallet/apl/util/cdi/AplContainerBuilder.java
@@ -1,6 +1,7 @@
 package com.apollocurrency.aplwallet.apl.util.cdi;
 
 import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
+import org.jboss.weld.config.ConfigurationKey;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
 import org.slf4j.Logger;
@@ -26,6 +27,8 @@ public class AplContainerBuilder {
 
     private List<Class<?>> interceptors;
 
+    private boolean concurrentDeploymentDisabled = false;
+
 //    private List<Class<?>> recursiveScanPackages;
 
     public AplContainerBuilder containerId(String id) {
@@ -48,6 +51,11 @@ public class AplContainerBuilder {
     public AplContainerBuilder devMode(){
         devMode=true;
         System.setProperty("org.jboss.weld.probe.jmxSupport", "true");
+        return this;
+    }
+
+    public AplContainerBuilder disableConcurrentDeployment(){
+        concurrentDeploymentDisabled = true;
         return this;
     }
 
@@ -87,6 +95,10 @@ public class AplContainerBuilder {
 
         if(devMode){
           weld.enableDevMode();
+        }
+
+        if(concurrentDeploymentDisabled){
+            weld.property(ConfigurationKey.CONCURRENT_DEPLOYMENT.get(), "false");
         }
 
         WeldContainer newContainer = weld.initialize();


### PR DESCRIPTION
Added command line parameter --disable-weld-concurrent-deployment to disable Weld concurrent deployment support. It's very helpful when the application is stuck during the Weld Container building. 