### PR TITLE
Apache Tika replaced by lightweight calls to JDK standard classes

### DIFF
--- a/apl-core/pom.xml
+++ b/apl-core/pom.xml
@@ -140,14 +140,14 @@
       <artifactId>paranamer</artifactId>
     </dependency>
 
-    <dependency>
+    <!--    <dependency>
       <groupId>javax.el</groupId>
       <artifactId>javax.el-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.web</groupId>
       <artifactId>javax.el</artifactId>
-    </dependency>
+    </dependency>-->
 
     <!-- Swagger runtime dependencies -->
     <!-- Swagger annotation for API auto-documenting -->

--- a/apl-core/pom.xml
+++ b/apl-core/pom.xml
@@ -84,7 +84,7 @@
       <artifactId>resteasy-jackson2-provider</artifactId>
     </dependency>
     <!-- we do not need validation at the moment, but keep in mind that it is interface
-    only and requires implementation laso, e.g hybernate-validator -->
+    only and requires implementation also, e.g hybernate-validator -->
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-validator-provider</artifactId>
@@ -140,14 +140,15 @@
       <artifactId>paranamer</artifactId>
     </dependency>
 
-    <!--    <dependency>
+    <!-- This stuff is used by hibernate-validator dynamically in runtime -->
+    <dependency>
       <groupId>javax.el</groupId>
       <artifactId>javax.el-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.web</groupId>
       <artifactId>javax.el</artifactId>
-    </dependency>-->
+    </dependency>
 
     <!-- Swagger runtime dependencies -->
     <!-- Swagger annotation for API auto-documenting -->

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/transaction/DigitalGoods.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/transaction/DigitalGoods.java
@@ -22,8 +22,7 @@ import com.apollocurrency.aplwallet.apl.core.transaction.messages.DigitalGoodsRe
 import com.apollocurrency.aplwallet.apl.core.transaction.messages.PrunablePlainMessageAppendix;
 import com.apollocurrency.aplwallet.apl.core.transaction.messages.UnencryptedDigitalGoodsDelivery;
 import com.apollocurrency.aplwallet.apl.util.Constants;
-import org.apache.tika.Tika;
-import org.apache.tika.mime.MediaType;
+import com.apollocurrency.aplwallet.apl.util.Search;
 import org.json.simple.JSONObject;
 import org.slf4j.Logger;
 
@@ -132,8 +131,8 @@ public abstract class DigitalGoods extends TransactionType {
             DigitalGoodsPriceChange attachment = (DigitalGoodsPriceChange) transaction.getAttachment();
             DGSGoods goods = lookupDGService().getGoods(attachment.getGoodsId());
             if (attachment.getPriceATM() <= 0
-                || attachment.getPriceATM() > lookupBlockchainConfig().getCurrentConfig().getMaxBalanceATM()
-                || (goods != null && transaction.getSenderId() != goods.getSellerId())) {
+                    || attachment.getPriceATM() > lookupBlockchainConfig().getCurrentConfig().getMaxBalanceATM()
+                    || (goods != null && transaction.getSenderId() != goods.getSellerId())) {
                 throw new AplException.NotValidException("Invalid digital goods price change: " + attachment.getJSONObject());
             }
             if (goods == null || goods.isDelisted()) {
@@ -272,10 +271,10 @@ public abstract class DigitalGoods extends TransactionType {
             DigitalGoodsPurchase attachment = (DigitalGoodsPurchase) transaction.getAttachment();
             DGSGoods goods = lookupDGService().getGoods(attachment.getGoodsId());
             if (attachment.getQuantity() <= 0
-                || attachment.getQuantity() > Constants.MAX_DGS_LISTING_QUANTITY
-                || attachment.getPriceATM() <= 0
-                || attachment.getPriceATM() > lookupBlockchainConfig().getCurrentConfig().getMaxBalanceATM()
-                || (goods != null && goods.getSellerId() != transaction.getRecipientId())) {
+                    || attachment.getQuantity() > Constants.MAX_DGS_LISTING_QUANTITY
+                    || attachment.getPriceATM() <= 0
+                    || attachment.getPriceATM() > lookupBlockchainConfig().getCurrentConfig().getMaxBalanceATM()
+                    || (goods != null && goods.getSellerId() != transaction.getRecipientId())) {
                 throw new AplException.NotValidException("Invalid digital goods purchase: " + attachment.getJSONObject());
             }
             if (transaction.getEncryptedMessage() != null && !transaction.getEncryptedMessage().isText()) {
@@ -370,10 +369,10 @@ public abstract class DigitalGoods extends TransactionType {
                 }
             }
             if (attachment.getDiscountATM() < 0
-                || attachment.getDiscountATM() > lookupBlockchainConfig().getCurrentConfig().getMaxBalanceATM()
-                || (purchase != null && (purchase.getBuyerId() != transaction.getRecipientId()
-                || transaction.getSenderId() != purchase.getSellerId()
-                || attachment.getDiscountATM() > Math.multiplyExact(purchase.getPriceATM(), (long) purchase.getQuantity())))) {
+                    || attachment.getDiscountATM() > lookupBlockchainConfig().getCurrentConfig().getMaxBalanceATM()
+                    || (purchase != null && (purchase.getBuyerId() != transaction.getRecipientId()
+                    || transaction.getSenderId() != purchase.getSellerId()
+                    || attachment.getDiscountATM() > Math.multiplyExact(purchase.getPriceATM(), (long) purchase.getQuantity())))) {
                 throw new AplException.NotValidException("Invalid digital goods delivery: " + attachment.getJSONObject());
             }
             if (purchase == null || purchase.getEncryptedGoods() != null) {
@@ -513,9 +512,9 @@ public abstract class DigitalGoods extends TransactionType {
             DigitalGoodsRefund attachment = (DigitalGoodsRefund) transaction.getAttachment();
             DGSPurchase purchase = lookupDGService().getPurchase(attachment.getPurchaseId());
             if (attachment.getRefundATM() < 0
-                || attachment.getRefundATM() > lookupBlockchainConfig().getCurrentConfig().getMaxBalanceATM()
-                || (purchase != null && (purchase.getBuyerId() != transaction.getRecipientId()
-                || transaction.getSenderId() != purchase.getSellerId()))) {
+                    || attachment.getRefundATM() > lookupBlockchainConfig().getCurrentConfig().getMaxBalanceATM()
+                    || (purchase != null && (purchase.getBuyerId() != transaction.getRecipientId()
+                    || transaction.getSenderId() != purchase.getSellerId()))) {
                 throw new AplException.NotValidException("Invalid digital goods refund: " + attachment.getJSONObject());
             }
             if (transaction.getEncryptedMessage() != null && !transaction.getEncryptedMessage().isText()) {
@@ -598,15 +597,14 @@ public abstract class DigitalGoods extends TransactionType {
             if (prunablePlainMessage != null) {
                 byte[] image = prunablePlainMessage.getMessage();
                 if (image != null) {
-                    Tika tika = new Tika();
-                    MediaType mediaType = null;
+                    String mediaType = null;
                     try {
-                        String mediaTypeName = tika.detect(image);
-                        mediaType = MediaType.parse(mediaTypeName);
+                        String mediaTypeName = Search.detectMimeType(image);
+                        mediaType = mediaTypeName.substring(0, mediaTypeName.indexOf("/"));
                     } catch (NoClassDefFoundError e) {
                         LOG.error("Error running Tika parsers", e);
                     }
-                    if (mediaType == null || !"image".equals(mediaType.getType())) {
+                    if (mediaType == null || !"image".equals(mediaType)) {
                         throw new AplException.NotValidException("Only image attachments allowed for DGS listing, media type is " + mediaType);
                     }
                 }

--- a/apl-utils/pom.xml
+++ b/apl-utils/pom.xml
@@ -87,11 +87,7 @@
       <groupId>org.bitlet</groupId>
       <artifactId>weupnp</artifactId>
     </dependency>
-    <!-- Apache Tika libs-->
-    <dependency>
-      <groupId>org.apache.tika</groupId>
-      <artifactId>tika-core</artifactId>
-    </dependency>
+
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
       <artifactId>weld-se-core</artifactId>

--- a/apl-utils/src/main/java/com/apollocurrency/aplwallet/apl/util/Search.java
+++ b/apl-utils/src/main/java/com/apollocurrency/aplwallet/apl/util/Search.java
@@ -14,21 +14,24 @@
  *
  */
 
-/*
+ /*
  * Copyright © 2018 Apollo Foundation
  */
-
 package com.apollocurrency.aplwallet.apl.util;
 
 import com.apollocurrency.aplwallet.apl.crypto.Convert;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
-import org.apache.tika.Tika;
 import org.slf4j.Logger;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.FileNameMap;
+import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -36,6 +39,7 @@ import java.util.regex.Pattern;
 import static org.slf4j.LoggerFactory.getLogger;
 
 public final class Search {
+
     private static final Logger LOG = getLogger(Search.class);
 
     private static final Analyzer analyzer = new StandardAnalyzer();
@@ -52,8 +56,8 @@ public final class Search {
             CharTermAttribute attribute = stream.addAttribute(CharTermAttribute.class);
             String tag;
             stream.reset();
-            while (stream.incrementToken() && list.size() < maxTagCount &&
-                (tag = attribute.toString()).length() <= maxTagLength && tag.length() >= minTagLength) {
+            while (stream.incrementToken() && list.size() < maxTagCount
+                    && (tag = attribute.toString()).length() <= maxTagLength && tag.length() >= minTagLength) {
                 if (!list.contains(tag)) {
                     list.add(tag);
                 }
@@ -65,25 +69,31 @@ public final class Search {
         return list.toArray(new String[0]);
     }
 
-    //TODO: remove apache tika, use something lighter
     public static String detectMimeType(byte[] data, String filename) {
-        Tika tika = new Tika();
-        return tika.detect(data, filename);
+        //try to guess from file magic numers, it is more reliable
+        String mimeType = detectMimeType(data);
+        if (mimeType == null) {
+            //guess from file name
+            FileNameMap fileNameMap = URLConnection.getFileNameMap();
+            mimeType = fileNameMap.getContentTypeFor("file://" + filename);
+        }
+        return mimeType;
     }
 
     public static String detectMimeType(byte[] data) {
-        Tika tika = new Tika();
+        String mimeType = null;
+        InputStream is = new BufferedInputStream(new ByteArrayInputStream(data));
         try {
-            return tika.detect(data);
-        } catch (NoClassDefFoundError e) {
-            LOG.error("Error running Tika parsers", e);
-            return null;
+            mimeType = URLConnection.guessContentTypeFromStream(is);
+        } catch (IOException ex) {
+            //do nothing, stream is in memory
         }
+        return mimeType;
     }
 
     protected static boolean parseIps(List<String> ips) {
         Pattern IP_PATTERN = Pattern.compile(
-            "^(([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.){3}([01]?\\d\\d?|2[0-4]\\d|25[0-5])$");
+                "^(([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.){3}([01]?\\d\\d?|2[0-4]\\d|25[0-5])$");
         return ips.stream().anyMatch(ip -> !IP_PATTERN.matcher(ip).matches());
     }
 


### PR DESCRIPTION
Apache tika was used to MIME type detection only. Replaces by standard jdk classes available since JDK7
javax.el API commented out. It is not used in code. Slight doubts exist that I is may be used in runtime by validators