### PR TITLE
Fix of run in Weld CDI development mode

### DIFF
--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/peer/TimeTraceDecoratedThreadPoolExecutor.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/peer/TimeTraceDecoratedThreadPoolExecutor.java
@@ -38,7 +38,7 @@ public class TimeTraceDecoratedThreadPoolExecutor extends DecoratedThreadPoolExe
 
 
     @Slf4j
-    private static class TimeThreadJob implements Event {
+    static class TimeThreadJob implements Event {
         private static final AtomicInteger taskIdCounter = new AtomicInteger(0);
         private volatile long startTime;
         private volatile long scheduleTime;

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/signature/SignatureToolFactory.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/signature/SignatureToolFactory.java
@@ -22,7 +22,7 @@ import java.util.Set;
  * @author andrii.zinchenko@firstbridge.io
  */
 @Slf4j
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.NONE)
 public class SignatureToolFactory {
 
     private static final SignatureVerifier[] validators = new SignatureVerifier[]
@@ -111,7 +111,7 @@ public class SignatureToolFactory {
         return signatureCredential;
     }
 
-    private static class MultiSigVerifierImpl implements SignatureVerifier {
+    static class MultiSigVerifierImpl implements SignatureVerifier {
 
         @Override
         public boolean verify(byte[] document, Signature signature, Credential credential) {
@@ -149,7 +149,7 @@ public class SignatureToolFactory {
         }
     }
 
-    private static class SignatureVerifierV1 implements SignatureVerifier {
+    static class SignatureVerifierV1 implements SignatureVerifier {
         @Override
         public boolean verify(byte[] document, Signature signature, Credential credential) {
             Objects.requireNonNull(document);
@@ -173,7 +173,7 @@ public class SignatureToolFactory {
         }
     }
 
-    private static class MultiSigSigner implements DocumentSigner {
+    static class MultiSigSigner implements DocumentSigner {
         @Override
         public Signature sign(byte[] document, Credential credential) {
             Objects.requireNonNull(document);
@@ -208,7 +208,7 @@ public class SignatureToolFactory {
         }
     }
 
-    private static class DocumentSignerV1 implements DocumentSigner {
+    static class DocumentSignerV1 implements DocumentSigner {
         @Override
         public Signature sign(byte[] document, Credential credential) {
             Objects.requireNonNull(document);

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/transaction/TransactionUtils.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/transaction/TransactionUtils.java
@@ -12,7 +12,7 @@ import org.json.simple.JSONObject;
 /**
  * @author andrii.zinchenko@firstbridge.io
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.NONE)
 public class TransactionUtils {
     public static boolean convertAppendixToString(StringBuilder builder, Appendix appendix) {
         if (appendix != null) {

--- a/apl-exec/src/main/java/com/apollocurrency/aplwallet/apl/exec/Apollo.java
+++ b/apl-exec/src/main/java/com/apollocurrency/aplwallet/apl/exec/Apollo.java
@@ -265,10 +265,14 @@ public class Apollo {
             // See https://docs.jboss.org/cdi/spec/2.0.EDR2/cdi-spec.html#se_bootstrap for more details
             // we already have it in beans.xml in core
             .annotatedDiscoveryMode();
+        
+        //!!!!!!!!!!!!!!
         //TODO:  turn it on periodically in development process to check CDI errors
         // Enable for development only, see http://weld.cdi-spec.org/news/2015/11/10/weld-probe-jmx/
         // run with ./bin/apl-run-jmx.sh
-        //.devMode()
+        // aplContainerBuilder.devMode();
+        //!!!!!!!!!!!!!!!
+        
         if (args.disableWeldConcurrentDeployment) {
             //It's very helpful when the application is stuck during the Weld Container building.
             log.info("The concurrent deployment of Weld container is disabled.");


### PR DESCRIPTION
Please do not use private constructors, use package-private. Weld CDI can not start in development mode in that case.