### PR TITLE
APL-1843 - Fix recipient save during TransactionApplier.apply for recipientId != 0

### DIFF
--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/state/account/AccountService.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/state/account/AccountService.java
@@ -125,4 +125,12 @@ public interface AccountService {
 
     //Delegated from  AccountPublicKeyService
     byte[] getPublicKeyByteArray(long id);
+
+    /**
+     * Creates an account with the given id and save empty public key entity into the public key table for it
+     * @param id new account id
+     * @param isGenesis whether the account belongs to genesis type or not
+     * @return created account
+     */
+    Account addAccount(long id, boolean isGenesis);
 }

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/state/account/impl/AccountServiceImpl.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/state/account/impl/AccountServiceImpl.java
@@ -520,5 +520,25 @@ public class AccountServiceImpl implements AccountService {
     public byte[] getPublicKeyByteArray(long id) {
         return accountPublicKeyService.getPublicKeyByteArray(id);
     }
+
+    @Override
+    public Account addAccount(long id, boolean isGenesis) {
+        Preconditions.checkArgument(id != 0, "Invalid accountId 0");
+        DbKey dbKey = AccountTable.newKey(id);
+        Account account = accountTable.get(dbKey);
+        if (account == null) {
+            account = new Account(id, dbKey);
+            PublicKey publicKey = accountPublicKeyService.getPublicKey(id);
+            if (publicKey == null) {
+                if (isGenesis) {
+                    publicKey = accountPublicKeyService.insertGenesisPublicKey(id);
+                } else {
+                    publicKey = accountPublicKeyService.insertNewPublicKey(id);
+                }
+            }
+            account.setPublicKey(publicKey);
+        }
+        return account;
+    }
 }
 

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/transaction/TransactionApplier.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/transaction/TransactionApplier.java
@@ -50,7 +50,7 @@ public class TransactionApplier {
         if (transaction.getRecipientId() != 0) {
             recipientAccount = accountService.getAccount(transaction.getRecipientId());
             if (recipientAccount == null) {
-                recipientAccount = accountService.createAccount(transaction.getRecipientId());
+                recipientAccount = accountService.addAccount(transaction.getRecipientId(), false);
             }
         }
         if (transaction.getReferencedTransactionFullHash() != null) {


### PR DESCRIPTION
Recipient account should be saved during applying transaction as it was in 1.44.7 version (addOrGetAccount method was calling here)