### PR TITLE
APL-1867 - Fix incorrect payload size calculation during Transaction-to-bytes serialization

### DIFF
--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/transaction/common/TxSerializerV1Impl.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/transaction/common/TxSerializerV1Impl.java
@@ -55,18 +55,15 @@ public class TxSerializerV1Impl extends AbstractTxSerializer {
             .write(transaction.getECBlockHeight())
             .write(transaction.getECBlockId());
 
-        payloadSize += buffer.size();
 
         for (Appendix appendage : transaction.getAppendages()) {
             appendage.putBytes(buffer);
-            payloadSize += appendage.getFullSize();
         }
         if (transaction.getVersion() >= 2) {
             if (transaction.getSignature() != null) {
                 buffer.concat(transaction.getSignature().bytes());
-                payloadSize += transaction.getSignature().getSize();
             }
         }
-        return payloadSize;
+        return buffer.size();
     }
 }


### PR DESCRIPTION
Fullsize for Prunable attachments also includes their 'prunable' data size, but Transaction.transactionBytes do not include this