### PR TITLE
APL-1896 Enlarge unconfirmed_transaction.prunable_json column text->longtext

### DIFF
--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/dao/blockchain/TransactionDaoImpl.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/dao/blockchain/TransactionDaoImpl.java
@@ -275,7 +275,6 @@ public class TransactionDaoImpl implements TransactionDao {
                          + "has_prunable_attachment, ec_block_height, ec_block_id, transaction_index) "
                          + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
                     int i = 0;
-                    log.debug("Save transaction {}", transaction.getId());
                     pstmt.setLong(++i, transaction.getId());
                     pstmt.setShort(++i, transaction.getDeadline());
                     DbUtils.setLongZeroToNull(pstmt, ++i, transaction.getRecipientId());

--- a/apl-db-updater/src/main/resources/db/migration/apl/V1_2__enlarge_prunable_json_column.sql
+++ b/apl-db-updater/src/main/resources/db/migration/apl/V1_2__enlarge_prunable_json_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `unconfirmed_transaction` MODIFY COLUMN `prunable_json` longtext COLLATE utf8mb4_unicode_ci DEFAULT NULL;


### PR DESCRIPTION
Default text format allows up to 64kb, but serialized to JSON file of 40/42kb size does not fit this restriction