### PR TITLE
APL-1886 Fix passphrase parameter's naming

### DIFF
--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/rest/endpoint/KeyStoreController.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/rest/endpoint/KeyStoreController.java
@@ -175,7 +175,7 @@ public class KeyStoreController {
     @Secured2FA
     @PermitAll
     public Response downloadKeyStore(@FormParam("account") String account,
-                                     @FormParam("passPhrase") String passphraseReq, @Context HttpServletRequest request) throws ParameterException, IOException {
+                                     @FormParam("passphrase") String passphraseReq, @Context HttpServletRequest request) throws ParameterException, IOException {
         String passphraseStr = HttpParameterParserUtil.getPassphrase(passphraseReq, true);
         long accountId = RestParametersParser.parseAccountId(account);
 


### PR DESCRIPTION
Need to  rename because of 'Security2FAInterceptor' incorrect behavior