### PR TITLE
APL-1922 - Replace Cache.asMap  streaming with arraylist streaming

### DIFF
--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/cache/RemovedTxsCacheConfig.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/cache/RemovedTxsCacheConfig.java
@@ -5,6 +5,7 @@
 package com.apollocurrency.aplwallet.apl.core.cache;
 
 import com.apollocurrency.aplwallet.apl.util.cache.CacheConfigurator;
+import com.apollocurrency.aplwallet.apl.util.cache.InMemoryCacheManager;
 
 import java.util.concurrent.TimeUnit;
 
@@ -14,7 +15,10 @@ public class RemovedTxsCacheConfig extends CacheConfigurator {
 
     public RemovedTxsCacheConfig(int priority) {
         super(CACHE_NAME,
-            8,
+            InMemoryCacheManager.newCalc()
+                .addLongPrimitive()
+                .addLongPrimitive()
+            .calc(),
             priority);
 
         cacheBuilder().expireAfterWrite(10, TimeUnit.MINUTES);


### PR DESCRIPTION
Fix ArrayIndexOutOfBoundsException. Guava's Cache.asMap doesn't guarantee consistency for an iterator when the cache is under concurrent changes