### PR TITLE
Fix/apl 1907 pruned prematurely

### DIFF
--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/app/AplCore.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/app/AplCore.java
@@ -232,6 +232,8 @@ public final class AplCore {
 
             aplAppStatus.durableTaskUpdate(initCoreTaskID, 52.5, "Exchange matcher initialization");
 
+            GenesisAccounts.init();
+
             tcs = CDI.current().select(IDexMatcherInterface.class).get();
             tcs.initialize();
 
@@ -241,7 +243,7 @@ public final class AplCore {
             blockchain = CDI.current().select(BlockchainImpl.class).get();
             blockchain.update();
             peers.init();
-            GenesisAccounts.init();
+
 
             aplAppStatus.durableTaskUpdate(initCoreTaskID, 55.0, "Apollo Account ledger initialization");
 

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/BlockchainImpl.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/BlockchainImpl.java
@@ -252,7 +252,7 @@ public class BlockchainImpl implements Blockchain {
             return null;
         }
         if (block.getTransactions() == null) {
-            block.setTransactions(getBlockTransactions(block.getId()));
+            block.setTransactions(getOrLoadTransactions(block));
         }
         PublicKey publicKey = publicKeyDao.searchAll(block.getGeneratorId());
         if (publicKey != null) {


### PR DESCRIPTION
Fixes two bugs:
1. PushBlock error: DoubleSpending - incorrect db transaction lifecycle during transactions verification and incorrect transactions removal
2. PushBlock error: Pruned Prematurely - prunable appendices were not loaded using Blockchainimpl.loadBlockData, and BlockchainImpl.getOrLoadTransactions had no effect for the block for which Blockchainimpl.loadBlockData executed