### PR TITLE
Fix: APL 1941-payload-size-mismatch-tn1

### DIFF
--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/blockchain/TransactionImpl.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/blockchain/TransactionImpl.java
@@ -28,7 +28,6 @@ import com.apollocurrency.aplwallet.apl.core.transaction.TransactionType;
 import com.apollocurrency.aplwallet.apl.core.transaction.TransactionTypes;
 import com.apollocurrency.aplwallet.apl.core.transaction.messages.AbstractAppendix;
 import com.apollocurrency.aplwallet.apl.core.transaction.messages.AbstractAttachment;
-import com.apollocurrency.aplwallet.apl.core.transaction.messages.Appendix;
 import com.apollocurrency.aplwallet.apl.core.transaction.messages.EncryptToSelfMessageAppendix;
 import com.apollocurrency.aplwallet.apl.core.transaction.messages.EncryptedMessageAppendix;
 import com.apollocurrency.aplwallet.apl.core.transaction.messages.MessageAppendix;
@@ -71,7 +70,6 @@ public class TransactionImpl implements Transaction {
     private final PrunablePlainMessageAppendix prunablePlainMessage;
     private final PrunableEncryptedMessageAppendix prunableEncryptedMessage;
     private final List<AbstractAppendix> appendages;
-    private final int appendagesSize;
     private volatile byte[] senderPublicKey;
     private volatile long feeATM; // remove final modifier to set fee outside the class TODO get back 'final' modifier
     private volatile Signature signature;
@@ -132,11 +130,6 @@ public class TransactionImpl implements Transaction {
             list.add(this.prunableEncryptedMessage);
         }
         this.appendages = Collections.unmodifiableList(list);
-        int appendagesSize = 0;
-        for (Appendix appendage : appendages) {
-            appendagesSize += appendage.getSize();
-        }
-        this.appendagesSize = appendagesSize;
         this.signature = builder.signature;
     }
 
@@ -311,13 +304,6 @@ public class TransactionImpl implements Transaction {
         return Convert.toHexString(getFullHash());
     }
 
-/*    @Override
-    public int getFullSize() {
-        if (fullSize <= 0) {
-            throwSignaturePreConditionError("FULL_SIZE");
-        }
-        return fullSize;
-    }*/
 
     @Override
     public long getSenderId() {

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/converter/db/UnconfirmedTransactionEntityToModelConverter.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/converter/db/UnconfirmedTransactionEntityToModelConverter.java
@@ -8,6 +8,7 @@ import com.apollocurrency.aplwallet.apl.core.blockchain.Transaction;
 import com.apollocurrency.aplwallet.apl.core.blockchain.TransactionBuilderFactory;
 import com.apollocurrency.aplwallet.apl.core.blockchain.UnconfirmedTransaction;
 import com.apollocurrency.aplwallet.apl.core.entity.blockchain.UnconfirmedTransactionEntity;
+import com.apollocurrency.aplwallet.apl.core.transaction.TransactionUtils;
 import com.apollocurrency.aplwallet.apl.util.api.converter.Converter;
 import com.apollocurrency.aplwallet.apl.util.exception.AplException;
 import org.json.simple.JSONObject;
@@ -40,7 +41,7 @@ public class UnconfirmedTransactionEntityToModelConverter implements Converter<U
             Transaction tx = transactionBuilderFactory.newTransaction(entity.getTransactionBytes(), prunableAttachments);
             tx.setHeight(entity.getHeight());
 
-            return new UnconfirmedTransaction(tx, entity.getArrivalTimestamp(), entity.getFeePerByte(), entity.getTransactionBytes().length);
+            return new UnconfirmedTransaction(tx, entity.getArrivalTimestamp(), entity.getFeePerByte(), TransactionUtils.calculateFullSize(tx, entity.getTransactionBytes().length));
         } catch (AplException.NotValidException e) {
             throw new RuntimeException(e.toString(), e);
         }

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/BlockchainProcessorImpl.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/BlockchainProcessorImpl.java
@@ -74,6 +74,7 @@ import com.apollocurrency.aplwallet.apl.core.shard.ShardImporter;
 import com.apollocurrency.aplwallet.apl.core.transaction.TransactionApplier;
 import com.apollocurrency.aplwallet.apl.core.transaction.TransactionJsonSerializer;
 import com.apollocurrency.aplwallet.apl.core.transaction.TransactionTypes;
+import com.apollocurrency.aplwallet.apl.core.transaction.TransactionUtils;
 import com.apollocurrency.aplwallet.apl.core.transaction.TransactionValidator;
 import com.apollocurrency.aplwallet.apl.core.transaction.common.TxBContext;
 import com.apollocurrency.aplwallet.apl.core.transaction.messages.AbstractAppendix;
@@ -819,7 +820,7 @@ public class BlockchainProcessorImpl implements BlockchainProcessor {
             calculatedTotalFee += transaction.getFeeATM();
             Result result = getTxByteArrayResult(transaction);
             digest.update(result.array());
-            payloadLength += result.payloadSize();
+            payloadLength += TransactionUtils.calculateFullSize(transaction, result.size());
         }
         if (calculatedTotalAmount != block.getTotalAmountATM() || calculatedTotalFee != block.getTotalFeeATM()) {
             throw new BlockNotAcceptedException(
@@ -1255,7 +1256,7 @@ public class BlockchainProcessorImpl implements BlockchainProcessor {
             digest.update(signedTxBytes.array());
             totalAmountATM += transaction.getAmountATM();
             totalFeeATM += transaction.getFeeATM();
-            payloadLength += signedTxBytes.payloadSize();
+            payloadLength += TransactionUtils.calculateFullSize(transaction, signedTxBytes.size());
         }
         byte[] payloadHash = digest.digest();
         digest.update(previousBlock.getGenerationSignature());

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/UnconfirmedTransactionCreator.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/UnconfirmedTransactionCreator.java
@@ -7,6 +7,7 @@ package com.apollocurrency.aplwallet.apl.core.service.blockchain;
 import com.apollocurrency.aplwallet.apl.core.blockchain.Transaction;
 import com.apollocurrency.aplwallet.apl.core.blockchain.UnconfirmedTransaction;
 import com.apollocurrency.aplwallet.apl.core.chainid.BlockchainConfig;
+import com.apollocurrency.aplwallet.apl.core.transaction.TransactionUtils;
 import com.apollocurrency.aplwallet.apl.util.io.PayloadResult;
 import com.apollocurrency.aplwallet.apl.util.io.Result;
 import com.apollocurrency.aplwallet.apl.core.service.appdata.TimeService;
@@ -35,7 +36,7 @@ public class UnconfirmedTransactionCreator {
     public UnconfirmedTransaction from(Transaction transaction, long arrivalTimestamp) {
         Result byteArrayTx = PayloadResult.createLittleEndianByteArrayResult();
         txBContext.createSerializer(transaction.getVersion()).serialize(transaction, byteArrayTx);
-        int fullSize = byteArrayTx.payloadSize();
+        int fullSize = TransactionUtils.calculateFullSize(transaction, byteArrayTx.size());
 
         return new UnconfirmedTransaction(transaction, arrivalTimestamp, transaction.getFeeATM() / fullSize, fullSize);
     }

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/transaction/TransactionUtils.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/transaction/TransactionUtils.java
@@ -69,6 +69,10 @@ public class TransactionUtils {
         return flags;
     }
 
+    public static int calculateFullSize(Transaction tx, int byteLength) {
+        return byteLength + tx.getAppendages().stream().mapToInt(app-> app.getFullSize() - app.getSize()).sum();
+    }
+
 
     public static byte[] calculateFullHash(byte[] unsignedTxBytes, byte[] signatureBytes) {
         //calculate transaction Id and full hash

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/transaction/TransactionUtils.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/transaction/TransactionUtils.java
@@ -69,8 +69,16 @@ public class TransactionUtils {
         return flags;
     }
 
-    public static int calculateFullSize(Transaction tx, int byteLength) {
-        return byteLength + tx.getAppendages().stream().mapToInt(app-> app.getFullSize() - app.getSize()).sum();
+    /**
+     * Calculates the full size of transaction using {@link Transaction} itself
+     * and it's default serialization size with appendices typically obtained using {@link com.apollocurrency.aplwallet.apl.core.transaction.common.TxSerializer}
+     * @param tx transaction with appendices to calculate full size
+     * @param txStandardByteSize default serialized size of given transaction obtained using {@link com.apollocurrency.aplwallet.apl.core.transaction.common.TxSerializer}
+     * @return full size of the given transaction
+     */
+    public static int calculateFullSize(Transaction tx, int txStandardByteSize) {
+        //byteLength acts here as tx size with appendices default size, to get tx size with appendices full size we need to substract default size and add full size
+        return txStandardByteSize + tx.getAppendages().stream().mapToInt(app-> app.getFullSize() - app.getSize()).sum();
     }
 
 

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/transaction/TransactionValidator.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/transaction/TransactionValidator.java
@@ -174,7 +174,7 @@ public class TransactionValidator {
         }
         Result byteArrayTx = PayloadResult.createLittleEndianByteArrayResult();
         txBContext.createSerializer(transaction.getVersion()).serialize(transaction, byteArrayTx);
-        int fullSize = byteArrayTx.payloadSize();
+        int fullSize = TransactionUtils.calculateFullSize(transaction, byteArrayTx.size());
         if (fullSize > blockchainConfig.getCurrentConfig().getMaxPayloadLength()) {
             throw new AplException.NotValidException("Transaction size " + fullSize + " exceeds maximum payload size");
         }

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/app/TransactionProcessorTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/app/TransactionProcessorTest.java
@@ -145,7 +145,7 @@ class TransactionProcessorTest {
             .when(processingService)
             .validateBeforeProcessing(any(UnconfirmedTransaction.class));
         doReturn(-9128485677221760321L).when(transaction).getId();
-        UnconfirmedTransaction unconfirmedTransaction = new UnconfirmedTransaction(transaction, expirationTimestamp, 10, 100);
+        UnconfirmedTransaction unconfirmedTransaction = new UnconfirmedTransaction(transaction, expirationTimestamp, 10, 176);
         doReturn(unconfirmedTransaction).when(unconfirmedTransactionCreator).from(eq(transaction), anyLong());
         doReturn(true).when(transactionValidator).verifySignature(transaction);
         doReturn(true).when(processingService).addNewUnconfirmedTransaction(any(UnconfirmedTransaction.class));
@@ -179,7 +179,7 @@ class TransactionProcessorTest {
             .when(processingService)
             .validateBeforeProcessing(any(UnconfirmedTransaction.class));
         doReturn(true).when(processingService).addNewUnconfirmedTransaction(any(UnconfirmedTransaction.class));
-        UnconfirmedTransaction unconfirmedTransaction = new UnconfirmedTransaction(transaction, expirationTimestamp, 10, 100);
+        UnconfirmedTransaction unconfirmedTransaction = new UnconfirmedTransaction(transaction, expirationTimestamp, 10, 176);
         doReturn(unconfirmedTransaction).when(unconfirmedTransactionCreator).from(eq(transaction), anyLong());
         doReturn(BLOCK_5_HEIGHT).when(blockchain).getHeight();
         doReturn(Long.valueOf(BLOCK_5_HEIGHT - 1)).when(blockchainConfig).getLastKnownBlock();

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/blockchain/TransactionImplTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/blockchain/TransactionImplTest.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright © 2018-2021 Apollo Foundation
+ */
+
+package com.apollocurrency.aplwallet.apl.core.blockchain;
+
+import com.apollocurrency.aplwallet.apl.core.chainid.BlockchainConfig;
+import com.apollocurrency.aplwallet.apl.core.service.state.account.AccountService;
+import com.apollocurrency.aplwallet.apl.core.signature.Signature;
+import com.apollocurrency.aplwallet.apl.core.transaction.TransactionUtils;
+import com.apollocurrency.aplwallet.apl.core.transaction.TransactionWrapperHelper;
+import com.apollocurrency.aplwallet.apl.core.transaction.common.TxBContext;
+import com.apollocurrency.aplwallet.apl.core.transaction.common.TxSerializer;
+import com.apollocurrency.aplwallet.apl.core.transaction.messages.ArbitraryMessageAttachment;
+import com.apollocurrency.aplwallet.apl.core.transaction.messages.EncryptToSelfMessageAppendix;
+import com.apollocurrency.aplwallet.apl.core.transaction.messages.PrunablePlainMessageAppendix;
+import com.apollocurrency.aplwallet.apl.core.transaction.types.messaging.ArbitraryMessageTransactionType;
+import com.apollocurrency.aplwallet.apl.crypto.Convert;
+import com.apollocurrency.aplwallet.apl.crypto.EncryptedData;
+import com.apollocurrency.aplwallet.apl.util.env.config.Chain;
+import com.apollocurrency.aplwallet.apl.util.io.PayloadResult;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+
+class TransactionImplTest {
+    @Test
+    void create() {
+        ArbitraryMessageAttachment arbitraryMessage = new ArbitraryMessageAttachment();
+        PrunablePlainMessageAppendix prunableAppendix = new PrunablePlainMessageAppendix("Prunable test message", true);
+        EncryptToSelfMessageAppendix encryptedAppendix = new EncryptToSelfMessageAppendix(new EncryptedData(new byte[64], new byte[16]), false, false);
+        ArbitraryMessageTransactionType txType = new ArbitraryMessageTransactionType(mock(BlockchainConfig.class), mock(AccountService.class));
+        Signature sig = mock(Signature.class);
+        doReturn(new byte[64]).when(sig).bytes();
+        TransactionImpl tx = new TransactionImpl.BuilderImpl((byte) 1, new byte[32], 100L, 5L, (short) 1440, arbitraryMessage, 250, txType)
+            .appendix(prunableAppendix)
+            .appendix(encryptedAppendix)
+            .ecBlockData(new EcBlockData(1111, 200))
+            .blockId(2222)
+            .blockTimestamp(270)
+            .signature(sig)
+            .index((short) 0).build();
+
+
+        // verify unable to get not initialized data (required TransactionImpl#sign method call
+        assertThrows(IllegalStateException.class, () -> tx.getFullHash());
+        assertThrows(IllegalStateException.class, () -> tx.getId());
+
+        PayloadResult result = PayloadResult.createLittleEndianByteArrayResult();
+        TxSerializer serializer = TxBContext.newInstance(mock(Chain.class)).createSerializer(1);
+        serializer.serialize(TransactionWrapperHelper.createUnsignedTransaction(tx), result);
+
+        // assert default size of attachments
+        assertEquals(294, result.size());
+
+        tx.sign(tx.getSignature(), result);
+
+        // assert prunable full size less than default size
+        int fullSize = TransactionUtils.calculateFullSize(tx, result.size());
+        assertEquals(283, fullSize);
+        assertEquals("0e1027383f91699ea81a4c70b3dd6f3b61eb17decca2768d470b4f7c44f93763", Convert.toHexString(tx.getFullHash()));
+        assertEquals(-7031929642451267570L, tx.getId());
+    }
+}


### PR DESCRIPTION
Fix transaction size calculation (derived from master's branch version), reason: fullSize for prunable attachments differs depending on data existence, so that getFullSize of Prunable attachments should be used when calculating payload size for consensus purposes <div>Add javadoc


[Changes reviewed on CodeStream](https://api.codestream.com/r/YJQEr_F-aATlXG_8/a_ApC4VpTXuEv_5otCz6Kg?src=GitHub) by ylarin, alzinchenko on May 13, 2021

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&amp;utm_medium=pr&amp;utm_campaign=github*com)</sup></div>