### PR TITLE
Fix: APL 1967-dex-operation-details-column-insufficient-size

### DIFF
--- a/apl-db-updater/src/main/resources/db/migration/apl/V1_3__enlarge_dex_operation_details_column.sql
+++ b/apl-db-updater/src/main/resources/db/migration/apl/V1_3__enlarge_dex_operation_details_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `dex_operation` MODIFY COLUMN `details` VARCHAR(5000) COLLATE utf8mb4_unicode_ci DEFAULT NULL;


### PR DESCRIPTION



[Changes reviewed on CodeStream](https://api.codestream.com/r/YJQEr_F-aATlXG_8/Li9eM4bCQHO2ICUkxlhz1A?src=GitHub) by alzinchenko on May 25, 2021

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>