### PR TITLE
Fix missing transactions issue on forks

### DIFF
--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/MemPool.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/MemPool.java
@@ -188,7 +188,8 @@ public class MemPool {
         return streamConverter.apply(table.getAll(from, to)).map(toModelConverter);
     }
 
-    public void addProcessLater(UnconfirmedTransaction unconfirmedTransaction) {
+    public void processLater(UnconfirmedTransaction unconfirmedTransaction) {
+        removedTransactions.invalidate(unconfirmedTransaction.getId());
         memoryState.processLater(unconfirmedTransaction);
     }
 

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/TransactionProcessorImpl.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/TransactionProcessorImpl.java
@@ -81,7 +81,7 @@ public class TransactionProcessorImpl implements TransactionProcessor {
     private final MemPool memPool;
     private final DatabaseManager databaseManager;
     private final UnconfirmedTransactionProcessingService processingService;
-    private final UnconfirmedTransactionCreator unconfirmedTransactionCreator;
+    private final UnconfirmedTransactionCreator unconfirmedTxCreator;
     private final MultiLock multiLock = new MultiLock(1000);
     private final ExecutorService executor = Executors.newSingleThreadExecutor(new NamedThreadFactory("AfterBlockPushTxRemovingPool"));
 
@@ -96,7 +96,7 @@ public class TransactionProcessorImpl implements TransactionProcessor {
                                     Blockchain blockchain, TransactionBuilderFactory transactionBuilderFactory,
                                     PrunableLoadingService prunableService,
                                     UnconfirmedTransactionProcessingService processingService,
-                                    UnconfirmedTransactionCreator unconfirmedTransactionCreator,
+                                    UnconfirmedTransactionCreator unconfirmedTxCreator,
                                     MemPool memPool) {
         this.transactionValidator = validator;
         this.txsEvent = Objects.requireNonNull(txEvent);
@@ -109,7 +109,7 @@ public class TransactionProcessorImpl implements TransactionProcessor {
         this.transactionBuilderFactory = transactionBuilderFactory;
         this.prunableService = prunableService;
         this.processingService = processingService;
-        this.unconfirmedTransactionCreator = unconfirmedTransactionCreator;
+        this.unconfirmedTxCreator = unconfirmedTxCreator;
         this.memPool = memPool;
     }
 
@@ -136,7 +136,7 @@ public class TransactionProcessorImpl implements TransactionProcessor {
             return;
         }
         transactionValidator.validateFully(transaction);
-        UnconfirmedTransaction unconfirmedTransaction = unconfirmedTransactionCreator.from(transaction, timeService.systemTimeMillis());
+        UnconfirmedTransaction unconfirmedTransaction = unconfirmedTxCreator.from(transaction, timeService.systemTimeMillis());
 
         UnconfirmedTxValidationResult validationResult = processingService.validateBeforeProcessing(unconfirmedTransaction);
         if (!validationResult.isOk()) {
@@ -236,16 +236,13 @@ public class TransactionProcessorImpl implements TransactionProcessor {
             if (blockchain.hasTransaction(transaction.getId())) {
                 continue;
             }
-            toProcessLater.add(transaction);
             log.trace("Process later tx {}", transaction.getId());
+            long arrivalTimestamp = Math.min(currentTime, Convert2.fromEpochTime(transaction.getTimestamp()));
             transaction.unsetBlock();
             transaction.resetFail();
-            memPool.addProcessLater(
-                unconfirmedTransactionCreator.from(
-                    transaction,
-                    Math.min(currentTime, Convert2.fromEpochTime(transaction.getTimestamp()))
-                )
-            );
+            UnconfirmedTransaction unconfirmedTx = unconfirmedTxCreator.from(transaction, arrivalTimestamp);
+            memPool.processLater(unconfirmedTx);
+            toProcessLater.add(transaction);
         }
         log.info("Will process later [{}]", toProcessLater.stream().map(Transaction::getStringId).collect(Collectors.joining(",")));
     }
@@ -270,7 +267,7 @@ public class TransactionProcessorImpl implements TransactionProcessor {
             for (Transaction transaction : transactions) {
                 try {
                     receivedTransactions.add(transaction);
-                    UnconfirmedTransaction unconfirmedTransaction = unconfirmedTransactionCreator.from(transaction, arrivalTimestamp);
+                    UnconfirmedTransaction unconfirmedTransaction = unconfirmedTxCreator.from(transaction, arrivalTimestamp);
                     UnconfirmedTxValidationResult validationResult = processingService.validateBeforeProcessing(unconfirmedTransaction);
                     if (validationResult.isOk()) {
                         transactionValidator.validateSufficiently(transaction);

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/MemPoolTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/MemPoolTest.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright © 2018-2021 Apollo Foundation
+ */
+
+package com.apollocurrency.aplwallet.apl.core.service.blockchain;
+
+import com.apollocurrency.aplwallet.apl.core.converter.db.UnconfirmedTransactionEntityToModelConverter;
+import com.apollocurrency.aplwallet.apl.core.converter.db.UnconfirmedTransactionModelToEntityConverter;
+import com.apollocurrency.aplwallet.apl.core.dao.appdata.UnconfirmedTransactionTable;
+import com.apollocurrency.aplwallet.apl.core.model.Transaction;
+import com.apollocurrency.aplwallet.apl.core.model.UnconfirmedTransaction;
+import com.google.common.cache.Cache;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MemPoolTest {
+
+    @Mock
+    UnconfirmedTransactionTable table;
+    @Mock
+    UnconfirmedTransactionEntityToModelConverter toModelConverter;
+    @Mock
+    UnconfirmedTransactionModelToEntityConverter toEntityConverter;
+    @Mock
+    MemPoolInMemoryState state;
+    @Mock
+    MemPoolConfig config;
+
+
+    @InjectMocks
+    MemPool memPool;
+
+
+    @Mock
+    UnconfirmedTransaction unconfirmedTx;
+    @Mock
+    Transaction tx;
+    @Mock
+    Cache removedTxsCache;
+
+    @Test
+    void processLaterTx() {
+        when(unconfirmedTx.getId()).thenReturn(1000L);
+
+        memPool.processLater(unconfirmedTx);
+
+        verify(removedTxsCache).invalidate(1000L);
+        verify(state).processLater(unconfirmedTx);
+    }
+
+
+}


### PR DESCRIPTION
The issue was related to the removedTx cache, which counted transaction as removed after first block pushed with it, after that, there was no possibility to create block with this transaction on the node during the following 10 minutes, what lead to the those transactions dismissing on the high forkable network

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>