### PR TITLE
APL-2086 -  Fix accountInfo response format

### DIFF
--- a/apl-api/src/main/java/com/apollocurrency/aplwallet/api/dto/DexCurrencyDTO.java
+++ b/apl-api/src/main/java/com/apollocurrency/aplwallet/api/dto/DexCurrencyDTO.java
@@ -1,3 +1,7 @@
+/*
+ *  Copyright © 2018-2021 Apollo Foundation
+ */
+
 package com.apollocurrency.aplwallet.api.dto;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -14,5 +18,5 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DexCurrencyDTO extends BaseDTO{
     private String currency;
-    private List<EthWalletKeyDTO> wallets;
+    private List<WalletDTO> wallets;
 }

--- a/apl-api/src/main/java/com/apollocurrency/aplwallet/api/dto/WalletDTO.java
+++ b/apl-api/src/main/java/com/apollocurrency/aplwallet/api/dto/WalletDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apollo Foundation.
+ * Copyright © 2018-2021 Apollo Foundation.
  */
 
 package com.apollocurrency.aplwallet.api.dto;
@@ -7,6 +7,7 @@ package com.apollocurrency.aplwallet.api.dto;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -22,7 +23,8 @@ import lombok.ToString;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Getter
 @Setter
-public class EthWalletKeyDTO {
+@EqualsAndHashCode
+public class WalletDTO {
     private String address;
     private String publicKey;
 }

--- a/apl-api/src/main/java/com/apollocurrency/aplwallet/api/dto/account/CurrenciesWalletsDTO.java
+++ b/apl-api/src/main/java/com/apollocurrency/aplwallet/api/dto/account/CurrenciesWalletsDTO.java
@@ -1,14 +1,13 @@
 /*
- * Copyright © 2018-2019 Apollo Foundation.
+ * Copyright © 2018-2021 Apollo Foundation.
  */
 
 package com.apollocurrency.aplwallet.api.dto.account;
 
-import com.apollocurrency.aplwallet.api.dto.AplWalletDTO;
 import com.apollocurrency.aplwallet.api.dto.BaseDTO;
-import com.apollocurrency.aplwallet.api.dto.EthWalletKeyDTO;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -26,16 +25,13 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Getter
 @Setter
-public class WalletKeysInfoDTO extends BaseDTO {
-    private String account;
-    private String accountRS;
-    private String publicKey;
+@EqualsAndHashCode
+public class CurrenciesWalletsDTO extends BaseDTO {
     private String passphrase;
-    private AplWalletDTO apl;
-    private List<EthWalletKeyDTO> eth = new ArrayList<>();
+    private List<CurrencyWalletsDTO> currencies = new ArrayList<>();
 
-    public void addEthWalletKey(EthWalletKeyDTO dto) {
-        eth.add(dto);
+    public void addWallet(CurrencyWalletsDTO dto) {
+        currencies.add(dto);
     }
 
 }

--- a/apl-api/src/main/java/com/apollocurrency/aplwallet/api/dto/account/CurrencyWalletsDTO.java
+++ b/apl-api/src/main/java/com/apollocurrency/aplwallet/api/dto/account/CurrencyWalletsDTO.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright © 2018-2021 Apollo Foundation
+ */
+
+package com.apollocurrency.aplwallet.api.dto.account;
+
+import com.apollocurrency.aplwallet.api.dto.WalletDTO;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Andrii Boiarskyi
+ * @see CurrenciesWalletsDTO
+ * @since 1.48.4
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CurrencyWalletsDTO {
+    private String currency;
+    private List<WalletDTO> wallets = new ArrayList<>();
+}

--- a/apl-conf/src/main/resources/conf-tn2/chains.json
+++ b/apl-conf/src/main/resources/conf-tn2/chains.json
@@ -50,47 +50,7 @@
         }
       },
       {
-        "height": 3000,
-        "maxNumberOfTransactions": 255,
-        "maxArbitraryMessageLength": 160,
-        "maxNumberOfChildAccounts": 10,
-        "blockTime": 2,
-        "maxBlockTimeLimit": 3,
-        "minBlockTimeLimit": 1,
-        "maxBalance": 30000000000,
-        "consensusSettings": {
-          "adaptiveForgingSettings": {
-            "enabled": "true",
-            "adaptiveBlockTime": 10
-          }
-        },
-        "transactionFeeSettings": {
-          "feeRates": [
-            {
-              "type": 1,
-              "subType": 1,
-              "baseFee": "1000"
-            },
-            {
-              "type": 1,
-              "subType": 6,
-              "baseFee": "5"
-            },
-            {
-              "type": 1,
-              "subType": 7,
-              "baseFee": "5"
-            },
-            {
-              "type": 1,
-              "subType": 8,
-              "baseFee": "5"
-            }
-          ]
-        }
-      },
-      {
-        "height": 186000,
+        "height": 10000,
         "maxNumberOfTransactions": 255,
         "maxArbitraryMessageLength": 160,
         "maxNumberOfChildAccounts": 10,
@@ -107,50 +67,6 @@
         "shardingSettings": {
           "enabled": true,
           "frequency": 2000
-        },
-        "transactionFeeSettings": {
-          "feeRates": [
-            {
-              "type": 1,
-              "subType": 1,
-              "baseFee": "1000"
-            },
-            {
-              "type": 1,
-              "subType": 6,
-              "baseFee": "5"
-            },
-            {
-              "type": 1,
-              "subType": 7,
-              "baseFee": "5"
-            },
-            {
-              "type": 1,
-              "subType": 8,
-              "baseFee": "5"
-            }
-          ]
-        }
-      },
-      {
-        "height": 135000,
-        "maxNumberOfTransactions": 255,
-        "maxArbitraryMessageLength": 160,
-        "maxNumberOfChildAccounts": 10,
-        "blockTime": 2,
-        "maxBlockTimeLimit": 3,
-        "minBlockTimeLimit": 1,
-        "maxBalance": 30000000000,
-        "consensusSettings": {
-          "adaptiveForgingSettings": {
-            "enabled": "true",
-            "adaptiveBlockTime": 10
-          }
-        },
-        "shardingSettings": {
-          "enabled": true,
-          "frequency": 800
         },
         "transactionFeeSettings": {
           "feeRates": [

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/http/HttpParameterParserUtil.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/http/HttpParameterParserUtil.java
@@ -135,7 +135,7 @@ public final class HttpParameterParserUtil {
     protected static AdminPasswordVerifier apw;
     protected static ElGamalEncryptor elGamal;
     protected static TimeService timeService;
-    private static AliasService ALIAS_SERVICE;// = CDI.current().select(AliasService.class).get();
+    private static AliasService aliasService;// = CDI.current().select(AliasService.class).get();
     private static BlockchainConfig blockchainConfig;
     private static Blockchain blockchain;
     private static AccountService accountService;
@@ -1157,11 +1157,29 @@ public final class HttpParameterParserUtil {
 
     }
 
+    public static void resetCDIComponents() {
+        apw = null;
+        elGamal = null;
+        timeService = null;
+        aliasService = null;
+        blockchainConfig = null;
+        blockchain = null;
+        accountService = null;
+        accountPublicKeyService = null;
+        assetService = null;
+        POLL_SERVICE = null;
+        currencyExchangeOfferFacade = null;
+        currencyService = null;
+        shufflingService = null;
+        transactionBuilderFactory = null;
+        KMSService = null;
+    }
+
     private static AliasService lookupAliasService() {
-        if (ALIAS_SERVICE == null) {
-            ALIAS_SERVICE = CDI.current().select(AliasService.class).get();
+        if (aliasService == null) {
+            aliasService = CDI.current().select(AliasService.class).get();
         }
-        return ALIAS_SERVICE;
+        return aliasService;
     }
 
     private static AdminPasswordVerifier lookupAdminPasswordVerifier() {

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/rest/endpoint/AccountController.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/rest/endpoint/AccountController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 Apollo Foundation
+ * Copyright © 2018-2021 Apollo Foundation
  */
 
 package com.apollocurrency.aplwallet.apl.core.rest.endpoint;
@@ -11,7 +11,7 @@ import com.apollocurrency.aplwallet.api.dto.account.AccountCurrencyDTO;
 import com.apollocurrency.aplwallet.api.dto.account.AccountDTO;
 import com.apollocurrency.aplwallet.api.dto.account.AccountKeyDTO;
 import com.apollocurrency.aplwallet.api.dto.account.AccountsCountDto;
-import com.apollocurrency.aplwallet.api.dto.account.WalletKeysInfoDTO;
+import com.apollocurrency.aplwallet.api.dto.account.CurrenciesWalletsDTO;
 import com.apollocurrency.aplwallet.api.dto.auth.TwoFactorAuthParameters;
 import com.apollocurrency.aplwallet.api.response.AccountAssetsCountResponse;
 import com.apollocurrency.aplwallet.api.response.AccountAssetsResponse;
@@ -22,12 +22,12 @@ import com.apollocurrency.aplwallet.api.response.AccountCurrencyResponse;
 import com.apollocurrency.aplwallet.api.response.AccountCurrentAskOrderIdsResponse;
 import com.apollocurrency.aplwallet.api.response.AccountNotFoundResponse;
 import com.apollocurrency.aplwallet.api.response.BlocksResponse;
-import com.apollocurrency.aplwallet.apl.core.model.Block;
 import com.apollocurrency.aplwallet.apl.core.entity.state.account.Account;
 import com.apollocurrency.aplwallet.apl.core.entity.state.account.AccountAsset;
 import com.apollocurrency.aplwallet.apl.core.entity.state.account.AccountCurrency;
 import com.apollocurrency.aplwallet.apl.core.entity.state.account.PublicKey;
 import com.apollocurrency.aplwallet.apl.core.entity.state.order.AskOrder;
+import com.apollocurrency.aplwallet.apl.core.model.Block;
 import com.apollocurrency.aplwallet.apl.core.rest.converter.Account2FAConverter;
 import com.apollocurrency.aplwallet.apl.core.rest.converter.Account2FADetailsConverter;
 import com.apollocurrency.aplwallet.apl.core.rest.converter.AccountAssetConverter;
@@ -249,7 +249,7 @@ public class AccountController {
         responses = {
             @ApiResponse(responseCode = "200", description = "Successful execution",
                 content = @Content(mediaType = "text/html",
-                    schema = @Schema(implementation = WalletKeysInfoDTO.class)))
+                    schema = @Schema(implementation = CurrenciesWalletsDTO.class)))
         })
     @PermitAll
     public Response generateAccount(@Parameter(description = "The passphrase") @FormParam("passphrase") String passphrase) {
@@ -262,7 +262,7 @@ public class AccountController {
             return response.error(ApiErrors.ACCOUNT_GENERATION_ERROR).build();
         }
 
-        WalletKeysInfoDTO dto = walletKeysConverter.convert(walletKeysInfo);
+        CurrenciesWalletsDTO dto = walletKeysConverter.convert(walletKeysInfo);
         if (StringUtils.isBlank(passphrase)) {
             dto.setPassphrase(walletKeysInfo.getPassphrase());
         }

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/rest/endpoint/KeyStoreController.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/rest/endpoint/KeyStoreController.java
@@ -1,3 +1,7 @@
+/*
+ *  Copyright © 2018-2021 Apollo Foundation
+ */
+
 package com.apollocurrency.aplwallet.apl.core.rest.endpoint;
 
 import com.apollocurrency.aplwallet.apl.core.http.HttpParameterParserUtil;
@@ -94,13 +98,13 @@ public class KeyStoreController {
 
         WalletKeysInfo keyStoreInfo = KMSService.getWalletInfo(accountId, passphraseStr);
 
-        if(keyStoreInfo == null){
+        if (keyStoreInfo == null) {
             return ResponseBuilder.apiError(ApiErrors.ACCOUNT_2FA_ERROR, "KeyStore or passPhrase is not valid.").build();
         }
-         secureStorageService.addUserPassPhrase(accountId, passphraseStr);
+        secureStorageService.addUserPassPhrase(accountId, passphraseStr);
 
-         WalletKeysConverter walletKeysConverter = new WalletKeysConverter();
-         return Response.ok(walletKeysConverter.apply(keyStoreInfo)).build();
+        WalletKeysConverter walletKeysConverter = new WalletKeysConverter();
+        return Response.ok(walletKeysConverter.apply(keyStoreInfo)).build();
     }
 
 

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/rest/converter/HttpRequestToCreateTransactionRequestConverterTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/rest/converter/HttpRequestToCreateTransactionRequestConverterTest.java
@@ -5,6 +5,7 @@
 package com.apollocurrency.aplwallet.apl.core.rest.converter;
 
 import com.apollocurrency.aplwallet.apl.core.entity.state.account.Account;
+import com.apollocurrency.aplwallet.apl.core.http.HttpParameterParserUtil;
 import com.apollocurrency.aplwallet.apl.core.http.ParameterException;
 import com.apollocurrency.aplwallet.apl.core.model.CreateTransactionRequest;
 import com.apollocurrency.aplwallet.apl.core.transaction.messages.OrdinaryPaymentAttachment;
@@ -13,6 +14,7 @@ import org.jboss.weld.junit.MockBean;
 import org.jboss.weld.junit5.EnableWeld;
 import org.jboss.weld.junit5.WeldInitiator;
 import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -40,6 +42,11 @@ class HttpRequestToCreateTransactionRequestConverterTest {
     void setUp() {
         doAnswer(e -> e.getArgument(0)).when(elGamalEncryptor).elGamalDecrypt(anyString());
         doReturn("secret").when(request).getParameter("secretPhrase");
+    }
+
+    @AfterEach
+    void tearDown() {
+        HttpParameterParserUtil.resetCDIComponents();
     }
 
     @Test

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/rest/endpoint/AbstractEndpointTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/rest/endpoint/AbstractEndpointTest.java
@@ -8,6 +8,7 @@ import com.apollocurrency.aplwallet.apl.core.rest.exception.ClientErrorException
 import com.apollocurrency.aplwallet.apl.core.rest.exception.ConstraintViolationExceptionMapper;
 import com.apollocurrency.aplwallet.apl.core.rest.exception.DefaultGlobalExceptionMapper;
 import com.apollocurrency.aplwallet.apl.core.rest.exception.IllegalArgumentExceptionMapper;
+import com.apollocurrency.aplwallet.apl.core.rest.exception.ParameterExceptionMapper;
 import com.apollocurrency.aplwallet.apl.core.rest.validation.BlockchainHeightValidator;
 import com.apollocurrency.aplwallet.apl.core.rest.validation.CustomValidatorFactory;
 import com.apollocurrency.aplwallet.apl.core.rest.validation.TimestampValidator;
@@ -44,7 +45,10 @@ public abstract class AbstractEndpointTest {
     public static final int CODE_2FA = 123456;
     public static final String PASSPHRASE = "123456";
     public static final String SECRET = "SuperSecretPhrase"; //accountId=-3831750337430207973
-    public static final String PUBLIC_KEY_SECRET = "ce2466ca75ba9703be43f24a9d638e0cc5005b41df72383cbf85093233c17e21"; //accountId=-3831750337430207973
+    public static final byte[] ETH_PRIVATE_KEY = SECRET.getBytes();
+    public static final String ETH_PUBLIC_KEY = "cd469185df58a4f26629a522658c1917f839c2f3b82ab16860f677501989bfa256fcd0043a39cc09a26dd2307c7a9c560ab6f40abfdc74c9f8924aa0aaba597d";
+    public static final String ETH_ADDRESS = "0xeba908a0ec5c553afb9251f293c4f2dc18494ec8";
+    public static final String PUBLIC_KEY_SECRET = "ce2466ca75ba9703be43f24a9d638e0cc5005b41df72383cbf85093233c17e21";
     public static final long ACCOUNT_ID_WITH_SECRET = -3831750337430207973L;
 
     static ObjectMapper mapper = new ObjectMapper();
@@ -77,7 +81,8 @@ public abstract class AbstractEndpointTest {
             .register(RestParameterExceptionMapper.class)
             .register(ConstraintViolationExceptionMapper.class)
             .register(IllegalArgumentExceptionMapper.class)
-            .register(ClientErrorExceptionMapper.class);
+            .register(ClientErrorExceptionMapper.class)
+            .register(ParameterExceptionMapper.class);
 
         doReturn(CURRENT_HEIGHT).when(blockchain).getHeight();
     }

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/rest/endpoint/Error.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/rest/endpoint/Error.java
@@ -1,8 +1,20 @@
+/*
+ *  Copyright © 2018-2021 Apollo Foundation
+ */
+
 package com.apollocurrency.aplwallet.apl.core.rest.endpoint;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@EqualsAndHashCode(exclude = "requestProcessingTime")
 public class Error {
     private String errorDescription;
     private int errorCode;

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/rest/endpoint/KeyStoreControllerTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/rest/endpoint/KeyStoreControllerTest.java
@@ -1,0 +1,131 @@
+/*
+ *  Copyright © 2018-2021 Apollo Foundation
+ */
+
+package com.apollocurrency.aplwallet.apl.core.rest.endpoint;
+
+import com.apollocurrency.aplwallet.api.dto.WalletDTO;
+import com.apollocurrency.aplwallet.api.dto.account.CurrenciesWalletsDTO;
+import com.apollocurrency.aplwallet.api.dto.account.CurrencyWalletsDTO;
+import com.apollocurrency.aplwallet.apl.core.http.HttpParameterParserUtil;
+import com.apollocurrency.aplwallet.apl.core.service.appdata.SecureStorageService;
+import com.apollocurrency.aplwallet.apl.crypto.Convert;
+import com.apollocurrency.aplwallet.apl.util.service.ElGamalEncryptor;
+import com.apollocurrency.aplwallet.vault.model.AplWalletKey;
+import com.apollocurrency.aplwallet.vault.model.ApolloFbWallet;
+import com.apollocurrency.aplwallet.vault.model.EthWalletKey;
+import com.apollocurrency.aplwallet.vault.model.WalletKeysInfo;
+import com.apollocurrency.aplwallet.vault.service.KMSService;
+import lombok.SneakyThrows;
+import org.jboss.resteasy.mock.MockHttpResponse;
+import org.jboss.weld.junit.MockBean;
+import org.jboss.weld.junit5.EnableWeld;
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@EnableWeld
+@ExtendWith(MockitoExtension.class)
+class KeyStoreControllerTest extends AbstractEndpointTest {
+    int maxKeystoreFileSize = 500;
+    @Mock
+    KMSService kmsService;
+    @Mock
+    SecureStorageService secureStorageService;
+    ElGamalEncryptor encryptor = mock(ElGamalEncryptor.class);
+
+    @WeldSetup
+    WeldInitiator weldInitiator = WeldInitiator.from()
+        .addBeans(MockBean.of(encryptor, ElGamalEncryptor.class)) // only for static CDI lookups
+        .build();
+
+
+    @Override
+    @BeforeEach
+    void setUp() {
+        super.setUp();
+        dispatcher.getRegistry().addSingletonResource( new KeyStoreController(kmsService, secureStorageService, maxKeystoreFileSize));
+    }
+
+    @AfterEach
+    void tearDown() {
+        HttpParameterParserUtil.resetCDIComponents(); // cleanup CDI lookups
+    }
+
+    @Test
+    @SneakyThrows
+    void getAccountInfo_noPassphrase() {
+        MockHttpResponse response = sendPostRequest("/keyStore/accountInfo", "account=" + Long.toUnsignedString(ACCOUNT_ID_WITH_SECRET));
+
+        assertEquals(200, response.getStatus(), "getAccountInfo error response should be always with code 200");
+        Error error = mapper.readValue(response.getContentAsString(), Error.class);
+        assertEquals(new Error("\"passphrase\" not specified", 3, 0, 0, 0), error);
+        verify(encryptor, never()).elGamalDecrypt(anyString());
+    }
+
+
+    @Test
+    @SneakyThrows
+    void getAccountInfo_walletNotExist() {
+        when(encryptor.elGamalDecrypt(PASSPHRASE)).thenReturn(PASSPHRASE);
+
+        MockHttpResponse response = sendPostRequest("/keyStore/accountInfo", "account=" + Long.toUnsignedString(ACCOUNT_ID_WITH_SECRET)
+                + "&passphrase=" + PASSPHRASE);
+
+        assertEquals(200, response.getStatus(), "getAccountInfo error response should be always with code 200");
+        Error error = mapper.readValue(response.getContentAsString(), Error.class);
+        assertEquals(new Error("Key for this account is not exist.", 22, 1, 2014, 0), error);
+    }
+
+    @Test
+    @SneakyThrows
+    void getAccountInfo_noKeystore() {
+        when(encryptor.elGamalDecrypt(PASSPHRASE)).thenReturn(PASSPHRASE);
+        when(kmsService.isWalletExist(ACCOUNT_ID_WITH_SECRET)).thenReturn(true);
+
+        MockHttpResponse response = sendPostRequest("/keyStore/accountInfo", "account=" + Long.toUnsignedString(ACCOUNT_ID_WITH_SECRET)
+            + "&passphrase=" + PASSPHRASE);
+
+        assertEquals(200, response.getStatus(), "getAccountInfo error response should be always with code 200");
+        Error error = mapper.readValue(response.getContentAsString(), Error.class);
+        assertEquals(new Error("KeyStore or passPhrase is not valid.", 22, 1, 2014, 0), error);
+    }
+
+
+    @Test
+    @SneakyThrows
+    void getAccountInfo_OK() {
+        when(encryptor.elGamalDecrypt(PASSPHRASE)).thenReturn(PASSPHRASE);
+        when(kmsService.isWalletExist(ACCOUNT_ID_WITH_SECRET)).thenReturn(true);
+        ApolloFbWallet wallet = new ApolloFbWallet();
+        wallet.addAplKey(new AplWalletKey(SECRET.getBytes()));
+        wallet.addEthKey(new EthWalletKey(SECRET.getBytes()));
+        when(kmsService.getWalletInfo(ACCOUNT_ID_WITH_SECRET, PASSPHRASE)).thenReturn(new WalletKeysInfo(wallet, PASSPHRASE));
+
+        MockHttpResponse response = sendPostRequest("/keyStore/accountInfo", "account=" + Long.toUnsignedString(ACCOUNT_ID_WITH_SECRET)
+            + "&passphrase=" + PASSPHRASE);
+
+        assertEquals(200, response.getStatus(), "getAccountInfo response should be always with code 200");
+        CurrenciesWalletsDTO expected = new CurrenciesWalletsDTO();
+        CurrencyWalletsDTO aplWallets = new CurrencyWalletsDTO("apl", List.of(new WalletDTO(Convert.defaultRsAccount(ACCOUNT_ID_WITH_SECRET), PUBLIC_KEY_SECRET)));
+        CurrencyWalletsDTO ethWallets = new CurrencyWalletsDTO("eth", List.of(new WalletDTO(ETH_ADDRESS, ETH_PUBLIC_KEY)));
+        expected.getCurrencies().add(aplWallets);
+        expected.getCurrencies().add(ethWallets);
+        CurrenciesWalletsDTO result = mapper.readValue(response.getContentAsString(), CurrenciesWalletsDTO.class);
+        assertEquals(expected, result);
+    }
+}

--- a/apl-utils/src/main/java/com/apollocurrency/aplwallet/apl/util/exception/ApiErrors.java
+++ b/apl-utils/src/main/java/com/apollocurrency/aplwallet/apl/util/exception/ApiErrors.java
@@ -53,9 +53,9 @@ public enum ApiErrors implements ApiErrorInfo {
     NOT_FOUND_ETH_ACCOUNT(0, 2203, "Incorrect ethereum address"),
     ;
 
-    private int oldErrorCode;
-    private int errorCode;
-    private String errorDescription;
+    private final int oldErrorCode;
+    private final int errorCode;
+    private final String errorDescription;
 
     ApiErrors(int oldErrorCode, int errorCode, String errorDescription) {
         this.oldErrorCode = oldErrorCode;

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <antifraud.version>1.1.3</antifraud.version>
 
     <!-- We have to define this property and change it accordingly for correct version of packages -->
-    <apl-bom-ext.version>1.0.6</apl-bom-ext.version>
+    <apl-bom-ext.version>1.0.8</apl-bom-ext.version>
     <base-dist-dir>ApolloWallet/apollo-blockchain</base-dist-dir>
 
     <build-helper-maven-plugin.version>1.9.1</build-helper-maven-plugin.version>


### PR DESCRIPTION
Fix /keyStore/accountInfo and /accounts/account endpoint responses, lower sharding height for tn2, add new mockito version bom

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>