### PR TITLE
APL-2093 - Fix incorrect initial block amount and total payload size during generation with failed txs.

### DIFF
--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/app/runnable/GetMoreBlocksJob.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/app/runnable/GetMoreBlocksJob.java
@@ -12,6 +12,7 @@ import com.apollocurrency.aplwallet.api.p2p.response.GetMilestoneBlockIdsRespons
 import com.apollocurrency.aplwallet.api.p2p.response.GetNextBlockIdsResponse;
 import com.apollocurrency.aplwallet.apl.core.app.GetNextBlocksTask;
 import com.apollocurrency.aplwallet.apl.core.chainid.BlockchainConfig;
+import com.apollocurrency.aplwallet.apl.core.exception.AplBlockException;
 import com.apollocurrency.aplwallet.apl.core.model.Block;
 import com.apollocurrency.aplwallet.apl.core.model.BlockchainProcessorState;
 import com.apollocurrency.aplwallet.apl.core.model.PeerBlock;
@@ -521,7 +522,7 @@ public class GetMoreBlocksJob implements Runnable {
                 if (blockchain.getLastBlock().getId() == block.getPreviousBlockId()) {
                     try {
                         blockchainProcessor.pushBlock(block);
-                    } catch (BlockchainProcessor.BlockNotAcceptedException e) {
+                    } catch (BlockchainProcessor.BlockNotAcceptedException | AplBlockException e) {
                         peerBlock.getPeer().blacklist(e);
                     }
                 } else {
@@ -555,7 +556,7 @@ public class GetMoreBlocksJob implements Runnable {
                     try {
                         blockchainProcessor.pushBlock(block);
                         pushedForkBlocks += 1;
-                    } catch (BlockchainProcessor.BlockNotAcceptedException e) {
+                    } catch (BlockchainProcessor.BlockNotAcceptedException | AplBlockException e) {
                         peer.blacklist(e);
                         break;
                     }
@@ -579,7 +580,7 @@ public class GetMoreBlocksJob implements Runnable {
                 Block block = myPoppedOffBlocks.remove(i);
                 try {
                     blockchainProcessor.pushBlock(block);
-                } catch (BlockchainProcessor.BlockNotAcceptedException e) {
+                } catch (BlockchainProcessor.BlockNotAcceptedException | AplBlockException e) {
                     log.error("Popped off block no longer acceptable: " + blockSerializer.getJSONObject(block).toJSONString(), e);
                     break;
                 }

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/exception/AplBlockException.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/exception/AplBlockException.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright © 2018-2021 Apollo Foundation
+ */
+
+package com.apollocurrency.aplwallet.apl.core.exception;
+
+import com.apollocurrency.aplwallet.apl.core.model.Block;
+import lombok.Getter;
+
+/**
+ * <p>Represents any block-related exception, including validation, serialization/deserialization, push/rollback/generate
+ * failures.
+ * </p>
+ * <p>Should be used as a base exception for derived classes, which are responsible for specific error cases</p>
+ * <p><b>NOTE: </b> Class is intended to fully replace
+ * {@link com.apollocurrency.aplwallet.apl.core.service.blockchain.BlockchainProcessor.BlockNotAcceptedException} and
+ * its hierarchy</p>
+ * @author Andrii Boiarskyi
+ * @see AplCoreLogicException
+ * @see com.apollocurrency.aplwallet.apl.core.service.blockchain.BlockchainProcessor.BlockNotAcceptedException
+ * @since 1.48.4
+ */
+@Getter
+public class AplBlockException extends AplCoreLogicException {
+    private final Block block;
+
+    public AplBlockException(String message, Block block) {
+        super(constructErrorMessage(message, block));
+        this.block = block;
+    }
+
+    public AplBlockException(String message, Throwable cause, Block block) {
+        super(constructErrorMessage(message, block), cause);
+        this.block = block;
+    }
+
+    private static String constructErrorMessage(String message, Block block) {
+        return message + ", block: " + block.getStringId();
+    }
+
+}

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/exception/AplBlockPayloadSizeMismatchException.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/exception/AplBlockPayloadSizeMismatchException.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright © 2018-2021 Apollo Foundation
+ */
+
+package com.apollocurrency.aplwallet.apl.core.exception;
+
+import com.apollocurrency.aplwallet.apl.core.model.Block;
+import lombok.Getter;
+
+/**
+ * Exception, specifying an exceptional case, where calculated block payload size using executed transactions (including
+ * failed txs state) doesn't match block declared and signed payload size
+ * @author Andrii Boiarskyi
+ * @see AplBlockException
+ * @see AplBlockTotalAmountMismatchException
+ * @since 1.48.4
+ */
+public class AplBlockPayloadSizeMismatchException extends AplBlockException {
+    @Getter
+    private final int calculatedPayloadLength;
+
+    public AplBlockPayloadSizeMismatchException(Block block, int calculatedPayloadLength) {
+        super("Transaction payload length " + calculatedPayloadLength + " does not match block payload length "
+            + block.getPayloadLength(), block);
+        this.calculatedPayloadLength = calculatedPayloadLength;
+    }
+}

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/exception/AplBlockTotalAmountMismatchException.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/exception/AplBlockTotalAmountMismatchException.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright © 2018-2021 Apollo Foundation
+ */
+
+package com.apollocurrency.aplwallet.apl.core.exception;
+
+import com.apollocurrency.aplwallet.apl.core.model.Block;
+import lombok.Getter;
+
+/**
+ * Block validation exception, specifying case, where calculated total block amount by successfully executed transactions
+ * amounts summarizing (failed txs amount are skipped) doesn't match to the declared and signed block total amount
+ * @author Andrii Boiarskyi
+ * @see AplBlockException
+ * @see AplBlockPayloadSizeMismatchException
+ * @since 1.48.4
+ */
+public class AplBlockTotalAmountMismatchException extends AplBlockException {
+    @Getter
+    private final long calculatedAmount;
+
+    public AplBlockTotalAmountMismatchException(Block block, long calculatedAmount) {
+        super("Declared block total amount " + block.getTotalAmountATM() + " doesn't match transaction totals " + calculatedAmount, block);
+        this.calculatedAmount = calculatedAmount;
+    }
+
+
+}

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/model/TxsVerificationResult.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/model/TxsVerificationResult.java
@@ -4,7 +4,6 @@
 
 package com.apollocurrency.aplwallet.apl.core.model;
 
-import com.apollocurrency.aplwallet.apl.core.service.blockchain.FailedTransactionVerificationServiceImpl;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -21,7 +20,7 @@ import java.util.stream.Collectors;
  * Failed transaction's verification container, consisting of fully verified and not verified transactions
  * @author Andrii Boiarskyi
  * @see VerifiedTransaction
- * @see FailedTransactionVerificationServiceImpl
+ * @see com.apollocurrency.aplwallet.apl.core.service.blockchain.FailedTransactionVerificationServiceImpl
  * @since 1.48.4
  */
 @EqualsAndHashCode

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/BlockchainProcessorImpl.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/BlockchainProcessorImpl.java
@@ -48,6 +48,9 @@ import com.apollocurrency.aplwallet.apl.core.entity.state.account.AccountControl
 import com.apollocurrency.aplwallet.apl.core.entity.state.phasing.PhasingPoll;
 import com.apollocurrency.aplwallet.apl.core.entity.state.phasing.PhasingPollResult;
 import com.apollocurrency.aplwallet.apl.core.exception.AplAcceptableTransactionValidationException;
+import com.apollocurrency.aplwallet.apl.core.exception.AplBlockException;
+import com.apollocurrency.aplwallet.apl.core.exception.AplBlockPayloadSizeMismatchException;
+import com.apollocurrency.aplwallet.apl.core.exception.AplBlockTotalAmountMismatchException;
 import com.apollocurrency.aplwallet.apl.core.exception.AplTransactionValidationException;
 import com.apollocurrency.aplwallet.apl.core.exception.AplUnacceptableTransactionValidationException;
 import com.apollocurrency.aplwallet.apl.core.files.shards.ShardsDownloadService;
@@ -370,7 +373,7 @@ public class BlockchainProcessorImpl implements BlockchainProcessor {
                         pushBlock(peerBlock);
                         transactionProcessor.processLater(lastBlock.getTransactions());
                         log.info("Last block {} was replaced by {} at height {}", lastBlock.getStringId(), peerBlock.getStringId(), blockchain.getHeight());
-                    } catch (BlockNotAcceptedException e) {
+                    } catch (BlockNotAcceptedException | AplBlockException e) {
                         log.info("Replacement block failed to be accepted, pushing back our last block");
                         pushBlock(lastBlock);
                         transactionProcessor.processLater(peerBlock.getTransactions());
@@ -486,6 +489,7 @@ public class BlockchainProcessorImpl implements BlockchainProcessor {
      * a real exception cause, this type of exceptions is rare and usually should not be handled, since something wrong
      * with the running environment: database deadlocks, timeout locking table, too many connections and so on
      * @throws com.apollocurrency.aplwallet.apl.core.service.blockchain.BlockchainProcessor.BlockNotAcceptedException in case of the block validation failure
+     * @throws AplBlockException same as above, but preferred
      */
     @Override
     public void pushBlock(final Block block) throws BlockNotAcceptedException {
@@ -545,9 +549,12 @@ public class BlockchainProcessorImpl implements BlockchainProcessor {
                     // Need to do so even in case of popOff failure or transaction rollback fatal error (SYS table lock, connection closed, etc)
                     blockchain.setLastBlock(previousLastBlock);
                 }
-                Throwable realEx = e.getCause();
+                Throwable realEx = e.getCause(); // try to throw real exception, but only if they are properly defined and expected
                 if (realEx instanceof BlockNotAcceptedException) {
                     throw (BlockNotAcceptedException) realEx;
+                }
+                if (realEx instanceof AplBlockException) {
+                    throw (AplBlockException) realEx;
                 }
                 throw e;
             }
@@ -814,26 +821,43 @@ public class BlockchainProcessorImpl implements BlockchainProcessor {
         digest.update(previousBlock.getGenerationSignature());
         final byte[] publicKey = Crypto.getPublicKey(keySeed);
         byte[] generationSignature = digest.digest(publicKey);
-//        blockchain.getOrLoadTransactions(previousBlock); // load transactions
         byte[] previousBlockHash = Crypto.sha256().digest(((BlockImpl) previousBlock).bytes());
         long baseTarget = blockchainConfig.getCurrentConfig().getInitialBaseTarget();
-        Block block = new BlockImpl(blockVersion, blockTimestamp, previousBlock.getId(), totalAmountATM, totalFeeATM, payloadLength,
-            payloadHash, publicKey, generationSignature, previousBlockHash, timeout, blockTransactions, keySeed, baseTarget);
-
-        try {
-            pushBlock(block);
-            blockEvent.select(literal(BlockEventType.BLOCK_GENERATED)).fire(block);
-            log.debug("Account " + Long.toUnsignedString(block.getGeneratorId()) + " generated block " + block.getStringId()
-                + " at height " + block.getHeight() + " timestamp " + block.getTimestamp() + " fee " + ((float) block.getTotalFeeATM()) / blockchainConfig.getOneAPL());
-        } catch (TransactionNotAcceptedException e) {
-            log.debug("Generate block failed: " + e.getMessage());
-            Transaction transaction = e.getTransaction();
-            log.debug("Removing invalid transaction: " + transaction.getStringId());
-            transactionProcessor.removeUnconfirmedTransaction(transaction);
-            throw e;
-        } catch (BlockNotAcceptedException e) {
-            log.debug("Generate block failed: " + e.getMessage());
-            throw e;
+        int generationFailCounter = 3;
+        AplBlockException lastException = null; // last actual payload/amount calculation exception
+        // TODO Replace by a separate block generation strategy without exception control flow
+        while (generationFailCounter-- > 0) { // try at most 3 times (max allowed number of block acceptance failures
+            // by payload size or amount = 2)
+            Block block = new BlockImpl(blockVersion, blockTimestamp, previousBlock.getId(), totalAmountATM, totalFeeATM, payloadLength,
+                payloadHash, publicKey, generationSignature, previousBlockHash, timeout, blockTransactions, keySeed, baseTarget);
+            try {
+                pushBlock(block);
+                blockEvent.select(literal(BlockEventType.BLOCK_GENERATED)).fire(block);
+                log.info("Account " + Long.toUnsignedString(block.getGeneratorId()) + " generated block " + block.getStringId()
+                    + " at height " + block.getHeight() + " timestamp " + block.getTimestamp() + " fee " + ((float) block.getTotalFeeATM()) / blockchainConfig.getOneAPL());
+                break;
+            } catch (TransactionNotAcceptedException e) {
+                log.debug("Generate block failed: " + e.getMessage());
+                Transaction transaction = e.getTransaction();
+                log.debug("Removing invalid transaction: " + transaction.getStringId());
+                transactionProcessor.removeUnconfirmedTransaction(transaction);
+                throw e;
+            } catch (BlockNotAcceptedException e) {
+                log.debug("Generate block failed: " + e.getMessage());
+                throw e;
+            } catch (AplBlockPayloadSizeMismatchException e) {
+                log.debug("Block payload mismatch, will try again with new value: " + e.getMessage());
+                payloadLength = e.getCalculatedPayloadLength(); // next generation attempt with updated payloadLength
+                lastException = e;
+            } catch (AplBlockTotalAmountMismatchException e) {
+                log.debug("Block total amount mismatch, will try again with new value: " + e.getMessage());
+                totalAmountATM = e.getCalculatedAmount(); // next generation attempt with updated totalAmount
+                lastException = e;
+            }
+            blockTransactions.forEach(Transaction::resetFail); // reset failed state after processing
+        }
+        if (lastException != null) {
+            throw lastException;
         }
     }
 
@@ -1563,16 +1587,20 @@ public class BlockchainProcessorImpl implements BlockchainProcessor {
      * failed transactions were properly counted
      * @param block block, which transactions should be validated
      * @param hasPrunedTransactions flag, indicating that at least one block transaction was pruned
-     * @throws BlockNotAcceptedException when total block amount doesn't match to the calculated amount from not
-     * failed transactions, and when payload length for the block doesn't match to the calculated payload for both executed
+     * @throws AplBlockTotalAmountMismatchException when total block amount doesn't match to the calculated amount from not
+     * failed transactions
+     * @throws AplBlockPayloadSizeMismatchException when payload length for the block doesn't match to the calculated payload for both executed
      * and failed transactions
      */
-    private void validateAfterExecution(Block block, boolean hasPrunedTransactions) throws BlockNotAcceptedException {
-        long calculatedBlockAmount = block.getTransactions().stream().filter(transaction -> !transaction.isFailed()).mapToLong(Transaction::getAmountATM).sum();
+    private void validateAfterExecution(Block block, boolean hasPrunedTransactions) {
+        long calculatedBlockAmount = block.getTransactions()
+            .stream()
+            .filter(transaction -> !transaction.isFailed())
+            .mapToLong(Transaction::getAmountATM)
+            .sum();
 
         if (calculatedBlockAmount != block.getTotalAmountATM()) {
-            throw new BlockNotAcceptedException(
-                "Total amount doesn't match transaction totals", blockSerializer.getJSONObject(block));
+            throw new AplBlockTotalAmountMismatchException(block, calculatedBlockAmount);
         }
         int calculatedPayloadLength = block.getTransactions()
             .stream()
@@ -1583,9 +1611,7 @@ public class BlockchainProcessorImpl implements BlockchainProcessor {
             }).sum();
 
         if (hasPrunedTransactions ? calculatedPayloadLength > block.getPayloadLength() : calculatedPayloadLength != block.getPayloadLength()) {
-            throw new BlockNotAcceptedException(
-                "Transaction payload length " + calculatedPayloadLength + " does not match block payload length "
-                    + block.getPayloadLength(), blockSerializer.getJSONObject(block));
+            throw new AplBlockPayloadSizeMismatchException(block, calculatedPayloadLength);
         }
     }
 


### PR DESCRIPTION
* Introduce AplBlockException hierarchy to replace BlockNotAcceptedException
* Introduce 3 generation attempts for new block with unknown number of failed transactions with overriding total block amount and payload size depending on the appearance of the failed transactions
* Add AplBlockException handling, same as for BlockNotAcceptedException
* Ensure state independence between block generation attempts
* TODO in future: replace 3-attempts generation algorithm by a refactored block generation strategy

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>