### PR TITLE
APL-2093 - Add consensus for failed txs verification

### DIFF
--- a/apl-api/src/main/java/com/apollocurrency/aplwallet/api/dto/BlockDTO.java
+++ b/apl-api/src/main/java/com/apollocurrency/aplwallet/api/dto/BlockDTO.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @AllArgsConstructor
@@ -42,6 +43,8 @@ public class BlockDTO extends BaseDTO {
     private String previousBlockHash;
     private String blockSignature;
     private String totalAmountATM;
+    private Integer numberOfFailedTxs;
+    private List<TxErrorHashDTO> txErrorHashes = new ArrayList<>();
 
     private List<TransactionDTO> transactions;
     private List executedPhasedTransactions;

--- a/apl-api/src/main/java/com/apollocurrency/aplwallet/api/dto/TxErrorHashDTO.java
+++ b/apl-api/src/main/java/com/apollocurrency/aplwallet/api/dto/TxErrorHashDTO.java
@@ -1,0 +1,22 @@
+/*
+ *  Copyright © 2018-2021 Apollo Foundation
+ */
+
+package com.apollocurrency.aplwallet.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author Andrii Boiarskyi
+ * @since 1.48.4
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class TxErrorHashDTO {
+    private String id;
+    private String errorHash;
+    private String error;
+}

--- a/apl-conf/src/main/resources/conf-tn2/chains.json
+++ b/apl-conf/src/main/resources/conf-tn2/chains.json
@@ -47,22 +47,6 @@
             "enabled": "true",
             "adaptiveBlockTime": 10
           }
-        }
-      },
-      {
-        "height": 10000,
-        "maxNumberOfTransactions": 255,
-        "maxArbitraryMessageLength": 160,
-        "maxNumberOfChildAccounts": 10,
-        "blockTime": 2,
-        "maxBlockTimeLimit": 3,
-        "minBlockTimeLimit": 1,
-        "maxBalance": 30000000000,
-        "consensusSettings": {
-          "adaptiveForgingSettings": {
-            "enabled": "true",
-            "adaptiveBlockTime": 10
-          }
         },
         "shardingSettings": {
           "enabled": true,

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/app/AplCore.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/app/AplCore.java
@@ -23,12 +23,12 @@ package com.apollocurrency.aplwallet.apl.core.app;
 
 import com.apollocurrency.aplwallet.apl.core.addons.AddOns;
 import com.apollocurrency.aplwallet.apl.core.chainid.BlockchainConfigUpdater;
+import com.apollocurrency.aplwallet.apl.core.db.DatabaseManager;
 import com.apollocurrency.aplwallet.apl.core.http.API;
 import com.apollocurrency.aplwallet.apl.core.http.APIProxy;
 import com.apollocurrency.aplwallet.apl.core.peer.PeersService;
 import com.apollocurrency.aplwallet.apl.core.rest.filters.ApiSplitFilter;
 import com.apollocurrency.aplwallet.apl.core.rest.service.TransportInteractionService;
-import com.apollocurrency.aplwallet.apl.core.db.DatabaseManager;
 import com.apollocurrency.aplwallet.apl.core.service.appdata.TimeService;
 import com.apollocurrency.aplwallet.apl.core.service.blockchain.AbstractBlockValidator;
 import com.apollocurrency.aplwallet.apl.core.service.blockchain.Blockchain;
@@ -36,6 +36,7 @@ import com.apollocurrency.aplwallet.apl.core.service.blockchain.BlockchainImpl;
 import com.apollocurrency.aplwallet.apl.core.service.blockchain.BlockchainProcessor;
 import com.apollocurrency.aplwallet.apl.core.service.blockchain.BlockchainProcessorImpl;
 import com.apollocurrency.aplwallet.apl.core.service.blockchain.DefaultBlockValidator;
+import com.apollocurrency.aplwallet.apl.core.service.blockchain.FailedTransactionVerificationService;
 import com.apollocurrency.aplwallet.apl.core.service.blockchain.MemPool;
 import com.apollocurrency.aplwallet.apl.core.service.blockchain.ShardingInitTaskBackgroundScheduler;
 import com.apollocurrency.aplwallet.apl.core.service.blockchain.TransactionProcessingTaskScheduler;
@@ -267,6 +268,7 @@ public final class AplCore {
             CDI.current().select(DexOperationService.class).get();
             CDI.current().select(TransactionProcessingTaskScheduler.class).get();
             CDI.current().select(ShardingInitTaskBackgroundScheduler.class).get();
+            CDI.current().select(FailedTransactionVerificationService.class).get();
 
             //start all background tasks
             taskDispatchManager.dispatch();

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/exception/AplBlockTxErrorResultsMismatchException.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/exception/AplBlockTxErrorResultsMismatchException.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright © 2018-2021 Apollo Foundation
+ */
+
+package com.apollocurrency.aplwallet.apl.core.exception;
+
+import com.apollocurrency.aplwallet.apl.core.model.Block;
+import com.apollocurrency.aplwallet.apl.core.model.TxErrorHash;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * Exception, thrown when declared and signed block transaction error statuses are different from the obtained
+ * by the block transactions execution
+ * @author Andrii Boiarskyi
+ * @see AplBlockException
+ * @see Block#checkFailedTxsExecution()
+ * @since 1.48.4
+ */
+public class AplBlockTxErrorResultsMismatchException extends AplBlockException {
+    @Getter
+    private final List<TxErrorHash> calculatedErrorHashes;
+
+    public AplBlockTxErrorResultsMismatchException(Block block, List<TxErrorHash> calculatedErrorHashes) {
+        super("Tx errors after execution: " + calculatedErrorHashes + " are not the same as declared: " + block.getTxErrorHashes(), block);
+        this.calculatedErrorHashes = calculatedErrorHashes;
+    }
+}

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/http/JSONData.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/http/JSONData.java
@@ -608,6 +608,17 @@ public final class JSONData {
                 }
             json.put("executedPhasedTransactions", phasedTransactions);
         }
+        JSONArray txErrorHashesArray = new JSONArray();
+        json.put("numberOfFailedTxs", block.getTxErrorHashes().size());
+        block.getTxErrorHashes().forEach(e-> {
+            JSONObject txErrorHash = new JSONObject();
+            txErrorHash.put("id", Long.toUnsignedString(e.getId()));
+            txErrorHash.put("errorHash", Convert.toHexString(e.getErrorHash()));
+            txErrorHash.put("error", e.getError());
+            txErrorHashesArray.add(txErrorHash);
+        });
+        json.put("txErrorHashes", txErrorHashesArray);
+
         return json;
     }
 

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/model/Block.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/model/Block.java
@@ -27,6 +27,11 @@ public interface Block {
 
     long getGeneratorId();
 
+    /**
+     * @return hashed failed tx statuses if any
+     */
+    List<TxErrorHash> getTxErrorHashes();
+
     byte[] getGeneratorPublicKey();
 
     boolean hasGeneratorPublicKey();
@@ -64,6 +69,14 @@ public interface Block {
     byte[] getBytes();
 
     boolean checkSignature();
+
+    /**
+     * Verify that declared failed txs with their statuses are the same as obtained by the node transaction
+     * execution. Assuming that transaction execution status was not inherited from the declared block data
+     * @throws com.apollocurrency.aplwallet.apl.core.exception.AplBlockTxErrorResultsMismatchException when
+     * declared tx execution status is not equal to the obtained result
+     */
+    void checkFailedTxsExecution();
 
     boolean hasLoadedData();
 

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/model/BlockImpl.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/model/BlockImpl.java
@@ -4,6 +4,7 @@
 
 package com.apollocurrency.aplwallet.apl.core.model;
 
+import com.apollocurrency.aplwallet.apl.core.exception.AplBlockTxErrorResultsMismatchException;
 import com.apollocurrency.aplwallet.apl.crypto.AplIdGenerator;
 import com.apollocurrency.aplwallet.apl.crypto.Convert;
 import com.apollocurrency.aplwallet.apl.crypto.Crypto;
@@ -14,6 +15,8 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+
 //TODO RawBlock impl (without consensus data)
 public final class BlockImpl implements Block {
     private final int version;
@@ -28,6 +31,7 @@ public final class BlockImpl implements Block {
     private final int timeout;
     private volatile byte[] generatorPublicKey;
     private volatile List<Transaction> blockTransactions = Collections.emptyList();
+    private volatile List<TxErrorHash> txErrorHashes = Collections.emptyList();
 
     private byte[] blockSignature;
     private BigInteger cumulativeDifficulty;
@@ -136,6 +140,12 @@ public final class BlockImpl implements Block {
     @Override
     public long getPreviousBlockId() {
         return previousBlockId;
+    }
+
+
+    @Override
+    public List<TxErrorHash> getTxErrorHashes() {
+        return txErrorHashes;
     }
 
     @Override
@@ -284,13 +294,13 @@ public final class BlockImpl implements Block {
         if (bytes == null) {
             ByteBuffer buffer =
                 ByteBuffer.allocate(4 + 4 + 8 + 4 + 8 + 8 + 4 + 32 + 32 + 32 + 32 +
-                    (requireTimeout(version) ? 4 : 0) + (blockSignature != null ? 64 :
+                    (requireTimeout(version) ? 4 : 0)  + (40 * txErrorHashes.size())+ + (blockSignature != null ? 64 :
                     0));
             buffer.order(ByteOrder.LITTLE_ENDIAN);
             buffer.putInt(version);
             buffer.putInt(timestamp);
             buffer.putLong(previousBlockId);
-            buffer.putInt(blockTransactions != null ? blockTransactions.size() : /*getOrLoadTransactions().size()*/ 0);
+            buffer.putInt(blockTransactions.size());
             buffer.putLong(totalAmountATM);
             buffer.putLong(totalFeeATM);
             buffer.putInt(payloadLength);
@@ -301,6 +311,10 @@ public final class BlockImpl implements Block {
             if (requireTimeout(version)) {
                 buffer.putInt(timeout);
             }
+            txErrorHashes.forEach(e -> { // only when failed txs are present
+                buffer.putLong(e.getId());
+                buffer.put(e.getErrorHash());
+            });
             if (blockSignature != null) {
                 buffer.put(blockSignature);
             }
@@ -319,6 +333,15 @@ public final class BlockImpl implements Block {
     }
 
     @Override
+    public void checkFailedTxsExecution() {
+        // assuming transactions statuses were obtained by the node block txs execution with own statuses
+        List<TxErrorHash> actualErrors = obtainTxErrorHashes(blockTransactions);
+        if (!actualErrors.equals(txErrorHashes)) {
+            throw new AplBlockTxErrorResultsMismatchException(this, actualErrors);
+        }
+    }
+
+    @Override
     public String toString() {
         final StringBuffer sb = new StringBuffer("BlockImpl{");
         sb.append("version=").append(version);
@@ -327,7 +350,8 @@ public final class BlockImpl implements Block {
         sb.append(", totalAmountATM=").append(totalAmountATM);
         sb.append(", totalFeeATM=").append(totalFeeATM);
         sb.append(", timeout=").append(timeout);
-        sb.append(", blockTransactions=[").append(blockTransactions != null ? blockTransactions.size() : -1);
+        sb.append(", blockTransactions=[").append(blockTransactions.size());
+        sb.append(", txErrorHashes=[").append(txErrorHashes.stream().map(TxErrorHash::toString).collect(Collectors.joining(",")));
         sb.append("], baseTarget=").append(baseTarget);
         sb.append(", nextBlockId=").append(nextBlockId);
         sb.append(", height=").append(height);
@@ -346,6 +370,7 @@ public final class BlockImpl implements Block {
     @Override
     public void assignBlockData(List<Transaction> txs, byte[] generatorPublicKey) {
         this.blockTransactions = Collections.unmodifiableList(txs);
+        this.txErrorHashes = obtainTxErrorHashes(txs);
         this.generatorPublicKey = generatorPublicKey;
         if (generatorPublicKey != null) {
             this.generatorId = Convert.getId(generatorPublicKey);
@@ -362,4 +387,13 @@ public final class BlockImpl implements Block {
             transaction.setIndex(index++);
         }
     }
+
+    private List<TxErrorHash> obtainTxErrorHashes(List<Transaction> blockTransactions) {
+        return blockTransactions.stream()
+            .filter(Transaction::isFailed)
+            .map(tx -> new TxErrorHash(tx.getId(), tx.getErrorMessage()
+                .orElseThrow(() -> new IllegalStateException("Only failed txs should be added to the list of tx hashed errors"))))
+            .collect(Collectors.toList());
+    }
+
 }

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/model/TxErrorHash.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/model/TxErrorHash.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright © 2018-2021 Apollo Foundation
+ */
+
+package com.apollocurrency.aplwallet.apl.core.model;
+
+import com.apollocurrency.aplwallet.apl.crypto.Convert;
+import com.apollocurrency.aplwallet.apl.crypto.Crypto;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Hashed transaction failed status, signed by the block generator
+ * @author Andrii Boiarskyi
+ * @see Block
+ * @since 1.48.4
+ */
+@Getter
+@EqualsAndHashCode
+public class TxErrorHash {
+    private final long id;
+    private final byte[] errorHash;
+    private final String error;
+
+    public TxErrorHash(long id, String error) {
+        this.id = id;
+        this.error = error;
+        this.errorHash = Crypto.sha256().digest(error.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public String toString() {
+        return "TxErrorHash{" +
+            "id=" + Long.toUnsignedString(id) +
+            ", errorHash=" + Convert.toHexString(errorHash) +
+            ", error=" + error +
+            '}';
+    }
+}

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/rest/converter/BlockConverter.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/rest/converter/BlockConverter.java
@@ -6,6 +6,7 @@ package com.apollocurrency.aplwallet.apl.core.rest.converter;
 
 import com.apollocurrency.aplwallet.api.dto.BlockDTO;
 import com.apollocurrency.aplwallet.api.dto.TransactionDTO;
+import com.apollocurrency.aplwallet.api.dto.TxErrorHashDTO;
 import com.apollocurrency.aplwallet.apl.core.model.Block;
 import com.apollocurrency.aplwallet.apl.core.service.blockchain.Blockchain;
 import com.apollocurrency.aplwallet.apl.core.service.state.PhasingPollService;
@@ -73,6 +74,8 @@ public class BlockConverter implements Converter<Block, BlockDTO> {
         if (this.isAddPhasedTransactions) {
             this.addPhasedTransactions(dto, model);
         }
+        dto.setNumberOfFailedTxs(model.getTxErrorHashes().size());
+        model.getTxErrorHashes().forEach(e-> dto.getTxErrorHashes().add(new TxErrorHashDTO(Long.toUnsignedString(e.getId()), Convert.toHexString(e.getErrorHash()), e.getError())));
         return dto;
     }
 

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/FailedTransactionVerificationService.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/FailedTransactionVerificationService.java
@@ -39,7 +39,7 @@ public interface FailedTransactionVerificationService {
 
     /**
      * Launch batch failed transactions verification
-     * @return
+     * @return verification result
      */
     Optional<TxsVerificationResult> verifyTransactions();
 }

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/transaction/common/AbstractTxSerializer.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/transaction/common/AbstractTxSerializer.java
@@ -94,6 +94,7 @@ public abstract class AbstractTxSerializer implements TxSerializer {
         }
         json.put("ecBlockHeight", transaction.getECBlockHeight());
         json.put("ecBlockId", Long.toUnsignedString(transaction.getECBlockId()));
+        json.put("errorMessage", transaction.getErrorMessage().orElse(null));
         Signature signature = transaction.getSignature();
         if (signature != null) {
             json.put("signature", Convert.toHexString(signature.bytes()));

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/exception/AplBlockTxErrorResultsMismatchExceptionTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/exception/AplBlockTxErrorResultsMismatchExceptionTest.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright © 2018-2021 Apollo Foundation
+ */
+
+package com.apollocurrency.aplwallet.apl.core.exception;
+
+import com.apollocurrency.aplwallet.apl.core.model.TxErrorHash;
+import com.apollocurrency.aplwallet.apl.data.BlockTestData;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AplBlockTxErrorResultsMismatchExceptionTest {
+
+    @Test
+    void create() {
+        BlockTestData td = new BlockTestData();
+        TxErrorHash error = new TxErrorHash(-1, "Error");
+
+        AplBlockTxErrorResultsMismatchException ex = new AplBlockTxErrorResultsMismatchException(td.BLOCK_10, List.of(error));
+
+        assertEquals("Tx errors after execution: " +
+            "[TxErrorHash{id=18446744073709551615, " +
+            "errorHash=54a0e8c17ebb21a11f8a25b8042786ef7efe52441e6cc87e92c67e0c4c0c6e78, error=Error}] are not the same " +
+            "as declared: [TxErrorHash{id=9145605905642517648, " +
+            "errorHash=589985a3eb90ee4eb56ffb83f1d0e068171d1fa6d8be766e5953e30992398345, error=Transaction  " +
+            "#10 error message}," +
+            " TxErrorHash{id=16909767887484625916, " +
+            "errorHash=a603f3773430a7cc9f20f111a8fd3edd930bade6a4e7d4e05ebaee2a1b77172c, error=Transaction  #11 error message}]" +
+            ", block: 12239762356076828396", ex.getMessage());
+    }
+}

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/model/TxErrorHashTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/model/TxErrorHashTest.java
@@ -1,0 +1,24 @@
+/*
+ *  Copyright © 2018-2021 Apollo Foundation
+ */
+
+package com.apollocurrency.aplwallet.apl.core.model;
+
+import com.apollocurrency.aplwallet.apl.crypto.Convert;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TxErrorHashTest {
+
+    @Test
+    void create() {
+        TxErrorHash error = new TxErrorHash(Long.MIN_VALUE, "Tx Test Error");
+
+        assertEquals("6ea420146990f55001dcdab23dde17ae28b19a5a4744e8aff3427387df8432f2",
+            Convert.toHexString(error.getErrorHash()));
+        assertEquals("TxErrorHash{id=9223372036854775808," +
+            " errorHash=6ea420146990f55001dcdab23dde17ae28b19a5a4744e8aff3427387df8432f2, error=Tx Test Error}", error.toString());
+    }
+
+}

--- a/apl-exec/src/main/java/com/apollocurrency/aplwallet/apl/exec/Apollo.java
+++ b/apl-exec/src/main/java/com/apollocurrency/aplwallet/apl/exec/Apollo.java
@@ -207,7 +207,7 @@ public class Apollo {
 //cheat classloader to get access to "conf" package resources
         ConfPlaceholder ph = new ConfPlaceholder();
 
-//--------------- config locading section -------------------------------------
+//--------------- config locating section -------------------------------------
 
 //load configuration files
         EnvironmentVariables envVars = new EnvironmentVariables(Constants.APPLICATION_DIR_NAME);
@@ -235,7 +235,7 @@ public class Apollo {
             Constants.APPLICATION_DIR_NAME + ".properties",
             SYSTEM_PROPERTY_NAMES);
 
-// load everuthing into applicationProperies. This is the place where all configuration
+// load everything into applicationProperties. This is the place where all configuration
 // is collected from configs, command line and environment variables
         Properties applicationProperties = propertiesLoader.load();
 


### PR DESCRIPTION
* Lower number of generation attempts with failed txs to 2.
* First generation iteration includes a list of already failed by validation transactions to lower number of generation failure at first iteration
* Block now contains tx error hashes with tx ids (signed by the block generator), so that every node after txs execution can verify its results with the declared by the block generator and fail immediately, when it differs
* Block api responses updated to show number of failed txs in the block and its error hashes,
* FailedTransactionVerificationService is initialized before TaskDispatchManager to perform back up failed txs verification operations (just in case of programming errors)
* Update tn2 config to reset db for testing

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>