### PR TITLE
APL-2108 - Add handling of the shuffling validation error

### DIFF
--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/app/observer/ShufflerObserver.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/app/observer/ShufflerObserver.java
@@ -54,7 +54,6 @@ public class ShufflerObserver {
                     shuffler.setFailedTransaction(null);
                     shuffler.setFailureCause(null);
                 } catch (AplTransactionValidationException | AplMemPoolFullException ignore) {
-                    log.debug("");
                 }
             }
         }));

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/state/ShufflerServiceImpl.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/state/ShufflerServiceImpl.java
@@ -11,6 +11,7 @@ import com.apollocurrency.aplwallet.apl.core.entity.state.shuffling.Shuffler;
 import com.apollocurrency.aplwallet.apl.core.entity.state.shuffling.Shuffling;
 import com.apollocurrency.aplwallet.apl.core.entity.state.shuffling.ShufflingParticipant;
 import com.apollocurrency.aplwallet.apl.core.entity.state.shuffling.ShufflingParticipantState;
+import com.apollocurrency.aplwallet.apl.core.exception.AplAcceptableTransactionValidationException;
 import com.apollocurrency.aplwallet.apl.core.exception.AplTransactionValidationException;
 import com.apollocurrency.aplwallet.apl.core.exception.ShufflerException;
 import com.apollocurrency.aplwallet.apl.core.model.Transaction;
@@ -499,10 +500,10 @@ public class ShufflerServiceImpl implements ShufflerService {
                 processor.broadcast(transaction);
                 log.trace("Submitted Shuffling Tx: id: {}, participantAccount:{}, atm: {}, deadline: {}",
                     transaction.getId(), participantAccount, transaction.getAmountATM(), transaction.getDeadline());
-            } catch (AplMemPoolFullException e) {
+            } catch (AplMemPoolFullException | AplAcceptableTransactionValidationException e) {
                 shuffler.setFailedTransaction(transaction);
                 shuffler.setFailureCause(e);
-                log.debug("Error submitting shuffler transaction, mempool is full", e);
+                log.info("Error submitting shuffler transaction", e);
             } catch (AplTransactionIsAlreadyInMemPoolException e) {
                 log.warn("Transaction {} is already in mempool, possible synchronization issue appeared or before-check logic changed", transaction.getStringId());
             }


### PR DESCRIPTION
Add AplAcceptableTransactionValidationException catch statement with set of the Shuffler failedTx and and cause to provide the ability on startShuffler endpoint - throw an error with validation cause instead of silently adding invalid shuffler with no registration tx sent


[Changes reviewed on CodeStream](https://api.codestream.com/r/YJQEr_F-aATlXG_8/lAeOVx7aQumsJU63qgT_hA?src=GitHub) by alzinchenko on Oct 13, 2021

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>