### PR TITLE
APL-2110 - Fix account cache inconsistency

### DIFF
--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/dao/state/account/AccountTableCacheConfiguration.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/dao/state/account/AccountTableCacheConfiguration.java
@@ -7,6 +7,7 @@ package com.apollocurrency.aplwallet.apl.core.dao.state.account;
 import com.apollocurrency.aplwallet.apl.core.cache.AccountCacheConfig;
 import com.apollocurrency.aplwallet.apl.core.dao.state.keyfactory.DbKey;
 import com.apollocurrency.aplwallet.apl.core.entity.state.account.Account;
+import com.apollocurrency.aplwallet.apl.core.entity.state.account.PublicKey;
 import com.apollocurrency.aplwallet.apl.util.cache.InMemoryCacheManager;
 import com.apollocurrency.aplwallet.apl.util.cdi.config.Property;
 import com.apollocurrency.aplwallet.apl.util.service.TaskDispatchManager;
@@ -17,6 +18,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.PostConstruct;
+import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -71,11 +73,18 @@ public class AccountTableCacheConfiguration {
         log.info("Warming up {}", AccountCacheConfig.CACHE_NAME);
         List<Account> recentAccounts = accountTable.getRecentAccounts(10_000);
         Map<DbKey, Account> groupedRecentAccounts = recentAccounts.stream().collect(Collectors.toMap(AccountTableInterface::newKey, Function.identity()));
-        if (groupedRecentAccounts.size() != recentAccounts.size()) {
-            throw new IllegalStateException("Recent accounts from the AccountTable contains duplicates ");
-        }
         accountTableCache.putAll(groupedRecentAccounts);
         log.info("{} warm up is done with {} accounts", AccountCacheConfig.CACHE_NAME, groupedRecentAccounts.size());
+    }
+
+    void onPublicKeyAssigned(@Observes PublicKey publicKey) {
+        if (isCacheEnabled()) {
+            Account account = accountTableCache.getIfPresent(AccountTable.accountDbKeyFactory.newKey(publicKey.getAccountId()));
+            if (account != null && !publicKey.equals(account.getPublicKey())) {
+                log.info("--ACCOUNT CACHE-- Assign new public key {} for account {}", publicKey, account);
+                account.setPublicKey(publicKey);
+            }
+        }
     }
 
     @Produces

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/dao/state/derived/CachedTable.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/dao/state/derived/CachedTable.java
@@ -16,8 +16,8 @@ import java.util.Map;
 @Slf4j
 public class CachedTable<T extends DerivedEntity> extends DbTableWrapper<T> {
 
-    private final Cache<DbKey, T> cache;
-    private final Object lock = new Object();
+    protected final Cache<DbKey, T> cache;
+    protected final Object lock = new Object();
 
     public CachedTable(Cache<DbKey, T> cache, EntityDbTableInterface<T> table) {
         super(table);
@@ -88,11 +88,11 @@ public class CachedTable<T extends DerivedEntity> extends DbTableWrapper<T> {
         }
     }
 
-    private String tableName() {
+    protected String tableName() {
         return table.getName().toUpperCase();
     }
 
-    private String tableLogHeader() {
+    protected String tableLogHeader() {
         return "--" + tableName() + " " + "CACHE--";
     }
 

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/state/account/impl/AccountPublicKeyServiceImpl.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/state/account/impl/AccountPublicKeyServiceImpl.java
@@ -11,9 +11,11 @@ import com.apollocurrency.aplwallet.apl.core.service.state.account.AccountPublic
 import com.apollocurrency.aplwallet.apl.core.service.state.account.AccountService;
 import com.apollocurrency.aplwallet.apl.core.service.state.account.PublicKeyDao;
 import com.apollocurrency.aplwallet.apl.core.utils.EncryptedDataUtil;
+import com.apollocurrency.aplwallet.apl.crypto.Convert;
 import com.apollocurrency.aplwallet.apl.crypto.EncryptedData;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.enterprise.event.Event;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.Arrays;
@@ -27,11 +29,13 @@ import java.util.List;
 public class AccountPublicKeyServiceImpl implements AccountPublicKeyService {
     private final BlockChainInfoService blockChainInfoService;
     private final PublicKeyDao publicKeyDao;
+    private final Event<PublicKey> publicKeyEvent;
 
     @Inject
-    public AccountPublicKeyServiceImpl(BlockChainInfoService blockChainInfoService, PublicKeyDao publicKeyDao) {
+    public AccountPublicKeyServiceImpl(BlockChainInfoService blockChainInfoService, PublicKeyDao publicKeyDao, Event<PublicKey> publicKeyEvent) {
         this.blockChainInfoService = blockChainInfoService;
         this.publicKeyDao = publicKeyDao;
+        this.publicKeyEvent = publicKeyEvent;
     }
 
     @Override
@@ -141,6 +145,8 @@ public class AccountPublicKeyServiceImpl implements AccountPublicKeyService {
         //Such cases happens, because of air drop was on accounts id.
         if (publicKey.getPublicKey() == null) {
             publicKey.setPublicKey(key);
+            log.info("Assign public key for account {}, key {}, height {}", Long.toUnsignedString(account.getId()), Convert.toHexString(key),
+                blockChainInfoService.getHeight());
             insertPublicKey(publicKey, isGenesis);
         } else if (!Arrays.equals(publicKey.getPublicKey(), key)) {
             throw new IllegalStateException("Public key mismatch");
@@ -149,7 +155,10 @@ public class AccountPublicKeyServiceImpl implements AccountPublicKeyService {
                 insertPublicKey(publicKey, isGenesis);
             }
         }
+        // here we should update account cache by (only public key updated)
+        // to ensure that pubic key will be present, when account retrieved from cache
         account.setPublicKey(publicKey);
+        publicKeyEvent.fire(publicKey);
     }
 
     @Override

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/dao/state/account/AccountTableCacheConfigurationTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/dao/state/account/AccountTableCacheConfigurationTest.java
@@ -6,12 +6,14 @@ package com.apollocurrency.aplwallet.apl.core.dao.state.account;
 
 import com.apollocurrency.aplwallet.apl.core.dao.state.keyfactory.LongKey;
 import com.apollocurrency.aplwallet.apl.core.entity.state.account.Account;
+import com.apollocurrency.aplwallet.apl.core.entity.state.account.PublicKey;
 import com.apollocurrency.aplwallet.apl.data.AccountTestData;
 import com.apollocurrency.aplwallet.apl.util.cache.InMemoryCacheManager;
 import com.apollocurrency.aplwallet.apl.util.service.TaskDispatchManager;
 import com.apollocurrency.aplwallet.apl.util.task.Task;
 import com.apollocurrency.aplwallet.apl.util.task.TaskDispatcher;
 import com.google.common.cache.Cache;
+import com.google.common.cache.CacheStats;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -20,14 +22,19 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AccountTableCacheConfigurationTest {
@@ -58,9 +65,7 @@ class AccountTableCacheConfigurationTest {
     @Test
     void initWithCache() {
         setUp(true);
-
-        doReturn(cache).when(inMemoryCacheManager).acquireCache("ACCOUNT_CACHE");
-        doReturn(taskDispatcher).when(taskDispatchManager).newScheduledDispatcher("AccountTableProducer-periodics");
+        mockCacheAndDispatcher();
         doReturn(List.of(td.ACC_0, td.ACC_10, td.ACC_9)).when(accountTable).getRecentAccounts(10_000);
         doReturn("account_mock_table").when(accountTable).getName();
 
@@ -81,8 +86,9 @@ class AccountTableCacheConfigurationTest {
         doReturn(cache).when(inMemoryCacheManager).acquireCache("ACCOUNT_CACHE");
         doReturn(List.of(td.ACC_0, td.ACC_12, td.ACC_11)).when(accountTable).getRecentAccounts(10_000);
 
-        assertThrows(IllegalStateException.class, () -> cacheConfigurer.init());
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> cacheConfigurer.init());
 
+        assertTrue("Map collector should throw merge error exception", ex.getMessage().startsWith("Duplicate key LongKey{id=800}"));
         verify(cache, never()).putAll(anyMap());
         verify(taskDispatcher, never()).schedule(any(Task.class));
     }
@@ -97,5 +103,98 @@ class AccountTableCacheConfigurationTest {
         assertTrue("Expected AccountTable type for non-cached account table", table instanceof AccountTable);
 
         verifyNoInteractions(cache, taskDispatchManager, inMemoryCacheManager);
+    }
+
+    @Test
+    void testPublicKeyAssignedEvents_cacheEnabled_accountCached_noPublicKey() {
+        setUp(true);
+        mockCacheAndDispatcher();
+        cacheConfigurer.init();
+        PublicKey newAcc0Key = new PublicKey(td.ACC_0.getId(), new byte[32], td.ACC_0.getHeight() + 1);
+        when(cache.getIfPresent(new LongKey(td.ACC_0.getId()))).thenReturn(td.ACC_0);
+
+        cacheConfigurer.onPublicKeyAssigned(newAcc0Key);
+
+        assertEquals(newAcc0Key, td.ACC_0.getPublicKey());
+    }
+
+    @Test
+    void testPublicKeyAssignedEvents_cacheDisabled() {
+        setUp(false);
+        cacheConfigurer.init();
+        PublicKey newAcc0Key = new PublicKey(td.ACC_0.getId(), new byte[32], td.ACC_0.getHeight() + 1);
+
+        cacheConfigurer.onPublicKeyAssigned(newAcc0Key);
+
+        verifyNoInteractions(cache, accountTable);
+        assertNull("Account with id 50 should no have an assigned public key, because cache is not enabled", td.ACC_0.getPublicKey());
+    }
+
+    @Test
+    void testPublicKeyAssignedEvents_cacheEnabled_noAccount() {
+        setUp(true);
+        mockCacheAndDispatcher();
+        cacheConfigurer.init();
+        PublicKey newAcc0Key = new PublicKey(td.ACC_0.getId(), new byte[32], td.ACC_0.getHeight() + 1);
+
+        cacheConfigurer.onPublicKeyAssigned(newAcc0Key);
+
+        assertNull("Account with id 50 should no have an assigned public key, because that account is not cached", td.ACC_0.getPublicKey());
+    }
+
+    @Test
+    void testPublicKeyAssignedEvents_cacheEnabled_accountCached_publicKeyExistWithNoKey() {
+        setUp(true);
+        mockCacheAndDispatcher();
+
+        cacheConfigurer.init();
+        PublicKey newAcc0Key = new PublicKey(td.ACC_0.getId(), new byte[32], td.ACC_0.getHeight() + 1);
+        when(cache.getIfPresent(new LongKey(td.ACC_0.getId()))).thenReturn(td.ACC_0);
+        td.ACC_0.setPublicKey(new PublicKey(td.ACC_0.getId(), null, td.ACC_0.getHeight()));
+
+        cacheConfigurer.onPublicKeyAssigned(newAcc0Key);
+
+        assertEquals(newAcc0Key, td.ACC_0.getPublicKey());
+    }
+
+    @Test
+    void testPublicKeyAssignedEvents_cacheEnabled_accountCached_publicKeyExistWithLowerHeight() {
+        setUp(true);
+        mockCacheAndDispatcher();
+        doReturn(List.of(td.ACC_0, td.ACC_10, td.ACC_9)).when(accountTable).getRecentAccounts(10_000);
+        cacheConfigurer.init();
+        PublicKey newAcc0Key = new PublicKey(td.ACC_0.getId(), new byte[32], td.ACC_0.getHeight() + 1);
+        when(cache.getIfPresent(new LongKey(td.ACC_0.getId()))).thenReturn(td.ACC_0);
+        td.ACC_0.setPublicKey(new PublicKey(td.ACC_0.getId(), new byte[32], td.ACC_0.getHeight())); // existing key
+
+        cacheConfigurer.onPublicKeyAssigned(newAcc0Key);
+
+        assertEquals(newAcc0Key, td.ACC_0.getPublicKey());
+    }
+
+    @Test
+    void testPublicKeyAssignedEvents_cacheEnabled_accountCached_samePublicKeyExist() {
+        setUp(true);
+        mockCacheAndDispatcher();
+        doReturn(List.of(td.ACC_0, td.ACC_10, td.ACC_9)).when(accountTable).getRecentAccounts(10_000);
+        cacheConfigurer.init();
+        PublicKey newAcc0Key = new PublicKey(td.ACC_0.getId(), new byte[32], td.ACC_0.getHeight() + 1);
+        PublicKey existing = newAcc0Key.deepCopy();
+        td.ACC_0.setPublicKey(existing);
+        when(cache.getIfPresent(new LongKey(td.ACC_0.getId()))).thenReturn(td.ACC_0);
+
+        cacheConfigurer.onPublicKeyAssigned(newAcc0Key);
+
+        assertEquals(newAcc0Key, td.ACC_0.getPublicKey());
+    }
+
+    private void mockCacheAndDispatcher() {
+        doReturn(cache).when(inMemoryCacheManager).acquireCache("ACCOUNT_CACHE");
+        doReturn(taskDispatcher).when(taskDispatchManager).newScheduledDispatcher("AccountTableProducer-periodics");
+        doAnswer(a-> {
+            ((Task) a.getArgument(0)).run(); // simulate scheduled healtcheck execution and ensure no npe or other errors
+            return true;
+        }).when(taskDispatcher).schedule(any());
+        when(cache.stats()).thenReturn(mock(CacheStats.class));
     }
 }


### PR DESCRIPTION
Account is saved into account cache when inserted to db, but account also contains public key entity, which is managed by the application separately and may be updated outside the code, which inserts account to the db causing inconsistency between cached account public key inside the account cache and its db version. That case occurred in AccountPublicKeyServiceImpl.apply, when new key was saved into db but not updated inside the account cache (no accountTable.insert call) in the situation, where public key was assigned from the PublicKeyAnnouncementAppendix processing. It caused generation signature verification failure (effective balance = 0, because public key was null)