### PR TITLE
APL-2112 Fix DEX ETH stuck txs

### DIFF
--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/exchange/service/DexSmartContractServiceTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/exchange/service/DexSmartContractServiceTest.java
@@ -61,7 +61,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -107,7 +106,7 @@ class DexSmartContractServiceTest {
         service = spy(new DexSmartContractService(holder, dexEthService, ethereumWalletService, dexTransactionDao,
             dexBeanProducer, null, KMSService, chainId));
         walletCredentials = Credentials.create(ECKeyPair.create(Convert.parseHexString(ALICE_PRIV_KEY)));
-        gasInfo = new EthChainGasInfoImpl(100.5, 82.3, 53.9);
+        gasInfo = new EthChainGasInfoImpl(100L, 82L, 53L);
     }
 
 

--- a/apl-dex/src/main/java/com/apollocurrency/aplwallet/apl/dex/eth/model/EthChainGasInfoImpl.java
+++ b/apl-dex/src/main/java/com/apollocurrency/aplwallet/apl/dex/eth/model/EthChainGasInfoImpl.java
@@ -1,11 +1,15 @@
 package com.apollocurrency.aplwallet.apl.dex.eth.model;
 
 import com.apollocurrency.aplwallet.api.dto.EthGasInfoDto;
+import com.apollocurrency.aplwallet.apl.dex.eth.utils.EthUtil;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.Map;
 
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -13,17 +17,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class EthChainGasInfoImpl implements EthGasInfo {
     /**
-     * wei
+     * Gwei
      */
-    private Double fastSpeedPrice;
+    private Long fastSpeedPrice;
     /**
-     * wei
+     * Gwei
      */
-    private Double averageSpeedPrice;
+    private Long averageSpeedPrice;
     /**
-     * wei
+     * Gwei
      */
-    private Double safeLowSpeedPrice;
+    private Long safeLowSpeedPrice;
 
 
     public EthGasInfoDto toDto() {
@@ -35,39 +39,11 @@ public class EthChainGasInfoImpl implements EthGasInfo {
         return ethGasInfoDto;
     }
 
-    /**
-     * Gwei
-     */
-    public Long getFastSpeedPrice() {
-        return Double.valueOf(fastSpeedPrice).longValue();
-    }
-
-    @JsonProperty("fast")
-    public void setFastSpeedPrice(Double fastSpeedPrice) {
-        this.fastSpeedPrice = fastSpeedPrice;
-    }
-
-    /**
-     * Gwei
-     */
-    public Long getAverageSpeedPrice() {
-        return Double.valueOf(averageSpeedPrice).longValue();
-    }
-
-    @JsonProperty("standard")
-    public void setAverageSpeedPrice(Double averageSpeedPrice) {
-        this.averageSpeedPrice = averageSpeedPrice;
-    }
-
-    /**
-     * Gwei
-     */
-    public Long getSafeLowSpeedPrice() {
-        return Double.valueOf(safeLowSpeedPrice).longValue();
-    }
-
-    @JsonProperty("safeLow")
-    public void setSafeLowSpeedPrice(Double safeLowSpeedPrice) {
-        this.safeLowSpeedPrice = safeLowSpeedPrice;
+    @JsonProperty("data")
+    public void setData(Map<String, Object> data) {
+        // received data in wei
+        this.fastSpeedPrice = EthUtil.weiToGwei(BigDecimal.valueOf((Long) data.get("fast"))).toBigInteger().longValueExact();
+        this.averageSpeedPrice = EthUtil.weiToGwei(BigDecimal.valueOf((Long) data.get("standard"))).toBigInteger().longValueExact();
+        this.safeLowSpeedPrice = EthUtil.weiToGwei(BigDecimal.valueOf((Long) data.get("slow"))).toBigInteger().longValueExact();
     }
 }

--- a/apl-dex/src/main/java/com/apollocurrency/aplwallet/apl/dex/eth/service/DexEthService.java
+++ b/apl-dex/src/main/java/com/apollocurrency/aplwallet/apl/dex/eth/service/DexEthService.java
@@ -51,6 +51,7 @@ public class DexEthService {
                 ethGasInfo = ethGasStationInfoService.getEthPriceInfo();
 
                 if (ethGasInfo != null) {
+                    log.info("Received new gas price info from ETH Gas Station {}", ethGasInfo);
                     return ethGasInfo;
                 }
             } catch (Exception e) {
@@ -60,6 +61,7 @@ public class DexEthService {
                 ethGasInfo = ethGasStationInfoService.getEthChainPriceInfo();
 
                 if (ethGasInfo != null) {
+                    log.info("Received new gas price info from Etherchain {}", ethGasInfo);
                     return ethGasInfo;
                 }
             } catch (Exception e) {

--- a/apl-dex/src/main/java/com/apollocurrency/aplwallet/apl/dex/eth/utils/EthUtil.java
+++ b/apl-dex/src/main/java/com/apollocurrency/aplwallet/apl/dex/eth/utils/EthUtil.java
@@ -52,6 +52,10 @@ public class EthUtil {
         return convertToWei(gwei, EthUnit.GWEI);
     }
 
+    public static BigDecimal weiToGwei(BigDecimal wei) {
+        return Convert.fromWei(wei, Convert.Unit.GWEI);
+    }
+
     public static BigDecimal gweiToEth(Long gwei) {
         return weiToEther(gweiToWei(gwei));
     }

--- a/apl-dex/src/test/java/com/apollocurrency/aplwallet/apl/dex/eth/model/EthChainGasInfoImplTest.java
+++ b/apl-dex/src/test/java/com/apollocurrency/aplwallet/apl/dex/eth/model/EthChainGasInfoImplTest.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright © 2018-2021 Apollo Foundation
+ */
+
+package com.apollocurrency.aplwallet.apl.dex.eth.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EthChainGasInfoImplTest {
+    String gasNowResponse = "{\"code\":200,\"data\":{\"rapid\":83000000000,\"fast\":66186654643,\"standard\":46000000000,\"slow\":40000000000,\"timestamp\":1634805517872,\"priceUSD\":4182.36}}";
+    EthChainGasInfoImpl expected = new EthChainGasInfoImpl(66L, 46L, 40L);
+
+    @Test
+    void deserialize() throws JsonProcessingException {
+        EthChainGasInfoImpl actual = new ObjectMapper().readValue(gasNowResponse, EthChainGasInfoImpl.class);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void serialize() throws JsonProcessingException {
+        String json = new ObjectMapper().writeValueAsString(expected.toDto());
+
+        assertEquals("{\"fast\":\"66\",\"average\":\"46\",\"safeLow\":\"40\"}", json);
+    }
+
+}

--- a/apl-dex/src/test/java/com/apollocurrency/aplwallet/apl/dex/eth/utils/EthUtilTest.java
+++ b/apl-dex/src/test/java/com/apollocurrency/aplwallet/apl/dex/eth/utils/EthUtilTest.java
@@ -55,4 +55,18 @@ class EthUtilTest {
         Long apl = EthUtil.gweiToAtm(GWEI);
         assertEquals(ATM, apl);
     }
+
+    @Test
+    void weiToGwei_fractional() {
+        BigDecimal gwei = EthUtil.weiToGwei(new BigDecimal("10.2"));
+
+        assertEquals(new BigDecimal("0.0000000102"), gwei);
+    }
+
+    @Test
+    void weiToGwei_realValue() {
+        BigDecimal gwei = EthUtil.weiToGwei(new BigDecimal("2830000000000"));
+
+        assertEquals(new BigDecimal("2830"), gwei);
+    }
 }

--- a/apl-utils/src/main/java/com/apollocurrency/aplwallet/apl/util/Constants.java
+++ b/apl-utils/src/main/java/com/apollocurrency/aplwallet/apl/util/Constants.java
@@ -176,7 +176,7 @@ public final class Constants {
     public static String ETH_DEFAULT_ADDRESS = "0x0000000000000000000000000000000000000000";
     //DEX
     public static String ETH_STATION_GAS_INFO_URL = "https://www.ethgasstation.info/json/ethgasAPI.json";
-    public static String ETH_CHAIN_GAS_INFO_URL = "https://www.etherchain.org/api/gasPriceOracle";
+    public static String ETH_CHAIN_GAS_INFO_URL = "https://www.etherchain.org/api/gasnow";
     public static String ETH_GAS_INFO_URL = "https://ethgasstation.info/json/ethgasAPI.json";
     public static BigInteger ETH_MAX_POS_INT = new BigInteger("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16);
     //TODO calculate this value on the future.


### PR DESCRIPTION
Etherchain (our second gas price supplier) changed their API for getting eth gas price levels, so that their api at url: https://www.etherchain.org/api/gasPriceOracle now return bad data (1Gwei price), which is not appropriate gas price level to be included in the mined block (required strictly more than 1Gwei), so that they recommend using new api at url: https://www.etherchain.org/api/gasnow with a more accurate data specified in wei units

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>