### PR TITLE
APOLLO-26 - Add sort for getBlockchainTransactions request

### DIFF
--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/dao/blockchain/TransactionDao.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/dao/blockchain/TransactionDao.java
@@ -1,6 +1,7 @@
 package com.apollocurrency.aplwallet.apl.core.dao.blockchain;
 
 import com.apollocurrency.aplwallet.api.v2.model.TxReceipt;
+import com.apollocurrency.aplwallet.apl.core.model.Sort;
 import com.apollocurrency.aplwallet.apl.util.db.TransactionalDataSource;
 import com.apollocurrency.aplwallet.apl.core.entity.appdata.ChatInfo;
 import com.apollocurrency.aplwallet.apl.core.entity.blockchain.TransactionEntity;
@@ -50,7 +51,7 @@ public interface TransactionDao {
         long accountId, byte type, byte subtype,
         int blockTimestamp, boolean withMessage, boolean phasedOnly, boolean nonPhasedOnly,
         int from, int to, boolean executedOnly, boolean includePrivate,
-        int height, int prunableExpiration, boolean failedOnly, boolean nonFailedOnly);
+        int height, int prunableExpiration, boolean failedOnly, boolean nonFailedOnly, Sort sort);
 
     int getTransactionCountByFilter(
         TransactionalDataSource dataSource, long accountId,

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/dao/blockchain/TransactionDaoImpl.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/dao/blockchain/TransactionDaoImpl.java
@@ -29,6 +29,7 @@ import com.apollocurrency.aplwallet.apl.core.dao.exception.AplCoreDaoException;
 import com.apollocurrency.aplwallet.apl.core.db.DatabaseManager;
 import com.apollocurrency.aplwallet.apl.core.entity.appdata.ChatInfo;
 import com.apollocurrency.aplwallet.apl.core.entity.blockchain.TransactionEntity;
+import com.apollocurrency.aplwallet.apl.core.model.Sort;
 import com.apollocurrency.aplwallet.apl.core.model.TransactionDbInfo;
 import com.apollocurrency.aplwallet.apl.core.transaction.PrunableTransaction;
 import com.apollocurrency.aplwallet.apl.crypto.Convert;
@@ -381,14 +382,14 @@ public class TransactionDaoImpl implements TransactionDao {
         long accountId, byte type, byte subtype,
         int blockTimestamp, boolean withMessage, boolean phasedOnly, boolean nonPhasedOnly,
         int from, int to, boolean executedOnly, boolean includePrivate,
-        int height, int prunableExpiration, boolean failedOnly, boolean nonFailedOnly) {
+        int height, int prunableExpiration, boolean failedOnly, boolean nonFailedOnly, Sort sort) {
         validatePhaseAndNonPhasedTransactions(phasedOnly, nonPhasedOnly);
         validateFailedAndNonFailedTransactions(failedOnly, nonFailedOnly);
 
         StringBuilder buf = new StringBuilder();
         buf.append("SELECT transaction.* FROM transaction ");
         createTransactionSelectSqlWithOrder(buf, "transaction.*", type, subtype,
-            blockTimestamp, withMessage, phasedOnly, nonPhasedOnly, executedOnly, includePrivate, height, failedOnly, nonFailedOnly);
+            blockTimestamp, withMessage, phasedOnly, nonPhasedOnly, executedOnly, includePrivate, height, failedOnly, nonFailedOnly, sort);
         buf.append(DbUtils.limitsClause(from, to)); // append 'limit offset' clause
         try (Connection con = dataSource.getConnection()) {
             String sql = buf.toString();
@@ -874,9 +875,12 @@ public class TransactionDaoImpl implements TransactionDao {
         }
     }
 
-    private StringBuilder createTransactionSelectSqlWithOrder(StringBuilder buf, String selectString, byte type, byte subtype, int blockTimestamp, boolean withMessage, boolean phasedOnly, boolean nonPhasedOnly, boolean executedOnly, boolean includePrivate, int height, boolean failedOnly, boolean nonFailedOnly) {
+    private StringBuilder createTransactionSelectSqlWithOrder(StringBuilder buf, String selectString, byte type, byte subtype,
+                                                              int blockTimestamp, boolean withMessage, boolean phasedOnly,
+                                                              boolean nonPhasedOnly, boolean executedOnly, boolean includePrivate,
+                                                              int height, boolean failedOnly, boolean nonFailedOnly, Sort sort) {
         createTransactionSelectSqlNoOrder(buf, selectString, type, subtype, blockTimestamp, withMessage, phasedOnly, nonPhasedOnly, executedOnly, includePrivate, height, failedOnly, nonFailedOnly);
-        buf.append("ORDER BY block_timestamp DESC, transaction_index DESC");
+        buf.append("ORDER BY block_timestamp " + sort + ", transaction_index " + sort);
         return buf;
     }
 

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/db/DatabaseManagerImpl.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/db/DatabaseManagerImpl.java
@@ -36,6 +36,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Class is used for high level database and shard management.
@@ -178,6 +179,17 @@ public class DatabaseManagerImpl implements ShardManagement, DatabaseManager {
             .sorted(Comparator.reverseOrder())
             .map(id -> getOrCreateShardDataSourceById(id, new ShardAllScriptsDBUpdater()))
             .iterator();
+    }
+
+    @Override
+    public Iterator<TransactionalDataSource> getAllSortedDataSourcesIterator(Comparator<TransactionalDataSource> comparator) {
+        Set<Long> allFullShards = findAllFullShardId();
+        return
+            Stream.concat(allFullShards.stream()
+                    .map(id -> getOrCreateShardDataSourceById(id, new ShardAllScriptsDBUpdater())),
+                Stream.of(currentTransactionalDataSource))
+                .sorted(comparator)
+                .iterator();
     }
 
     /**

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/http/BlockEventSourceProcessor.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/http/BlockEventSourceProcessor.java
@@ -5,6 +5,7 @@
 package com.apollocurrency.aplwallet.apl.core.http;
 
 import com.apollocurrency.aplwallet.apl.core.model.Block;
+import com.apollocurrency.aplwallet.apl.core.model.Sort;
 import com.apollocurrency.aplwallet.apl.core.model.Transaction;
 import com.apollocurrency.aplwallet.apl.core.entity.state.account.Account;
 import com.apollocurrency.aplwallet.apl.core.entity.state.account.AccountAsset;
@@ -80,7 +81,7 @@ public class BlockEventSourceProcessor implements Runnable {
         List<Transaction> list = blockchain.getTransactions(accountId,
             0, (byte) -1, (byte) -1, 0, false,
             false, false, 0, 9, false,
-            false, false, false, false);
+            false, false, false, false, Sort.desc());
         for (Transaction transaction : list) {
             transactionsArray.add(JSONData.transaction(false, transaction));
         }

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/http/get/GetBlockchainTransactions.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/http/get/GetBlockchainTransactions.java
@@ -15,16 +15,17 @@
  */
 
 /*
- * Copyright © 2018-2019 Apollo Foundation
+ * Copyright © 2018-2021 Apollo Foundation
  */
 
 package com.apollocurrency.aplwallet.apl.core.http.get;
 
-import com.apollocurrency.aplwallet.apl.core.model.Transaction;
 import com.apollocurrency.aplwallet.apl.core.http.APITag;
 import com.apollocurrency.aplwallet.apl.core.http.AbstractAPIRequestHandler;
 import com.apollocurrency.aplwallet.apl.core.http.HttpParameterParserUtil;
 import com.apollocurrency.aplwallet.apl.core.http.JSONData;
+import com.apollocurrency.aplwallet.apl.core.model.Sort;
+import com.apollocurrency.aplwallet.apl.core.model.Transaction;
 import com.apollocurrency.aplwallet.apl.util.exception.AplException;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -43,7 +44,7 @@ public final class GetBlockchainTransactions extends AbstractAPIRequestHandler {
     public GetBlockchainTransactions() {
         super(new APITag[]{APITag.ACCOUNTS, APITag.TRANSACTIONS}, "account", "timestamp", "type", "subtype",
             "firstIndex", "lastIndex", "numberOfConfirmations", "withMessage", "phasedOnly", "nonPhasedOnly",
-            "includeExpiredPrunable", "includePhasingResult", "executedOnly", "failedOnly", "nonFailedOnly");
+            "includeExpiredPrunable", "includePhasingResult", "executedOnly", "failedOnly", "nonFailedOnly", "sort");
     }
 
     @Override
@@ -60,6 +61,12 @@ public final class GetBlockchainTransactions extends AbstractAPIRequestHandler {
         boolean executedOnly = "true".equalsIgnoreCase(req.getParameter("executedOnly"));
         boolean failedOnly = "true".equalsIgnoreCase(req.getParameter("failedOnly"));
         boolean nonFailedOnly = "true".equalsIgnoreCase(req.getParameter("nonFailedOnly"));
+        String sort = HttpParameterParserUtil.getStringParameter(req, "sort", false);
+
+        if (sort == null) {
+            sort = "DESC";
+        }
+        Sort sortObj = new Sort(sort);
 
         byte type;
         byte subtype;
@@ -82,7 +89,7 @@ public final class GetBlockchainTransactions extends AbstractAPIRequestHandler {
         JSONArray transactions = new JSONArray();
         List<Transaction> transactionList = lookupBlockchain().getTransactions(accountId, numberOfConfirmations,
             type, subtype, timestamp, withMessage, phasedOnly, nonPhasedOnly, firstIndex, lastIndex,
-            includeExpiredPrunable, executedOnly, false, failedOnly, nonFailedOnly);
+            includeExpiredPrunable, executedOnly, false, failedOnly, nonFailedOnly, sortObj);
         transactionList.forEach(tx -> transactions.add(JSONData.transaction(tx, includePhasingResult, false)));
 
         JSONObject response = new JSONObject();

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/http/get/GetPrivateBlockchainTransactions.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/http/get/GetPrivateBlockchainTransactions.java
@@ -5,6 +5,7 @@
 package com.apollocurrency.aplwallet.apl.core.http.get;
 
 import com.apollocurrency.aplwallet.apl.core.model.Block;
+import com.apollocurrency.aplwallet.apl.core.model.Sort;
 import com.apollocurrency.aplwallet.apl.core.model.Transaction;
 import com.apollocurrency.aplwallet.apl.core.http.APITag;
 import com.apollocurrency.aplwallet.apl.core.http.AbstractAPIRequestHandler;
@@ -77,7 +78,7 @@ public final class GetPrivateBlockchainTransactions extends AbstractAPIRequestHa
         } else {
             List<Transaction> transactionList = blockchain.getTransactions(
                 data.getAccountId(), 0, type, subtype, 0, false, false,
-                false, firstIndex, lastIndex, false, false, true, false, false);
+                false, firstIndex, lastIndex, false, false, true, false, false, Sort.desc());
             transactionList.forEach(tx -> {
 
                 if (TransactionTypes.TransactionTypeSpec.PRIVATE_PAYMENT == tx.getType().getSpec() && data.isEncrypt()) {

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/model/Sort.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/model/Sort.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright © 2018-2021 Apollo Foundation
+ */
+
+package com.apollocurrency.aplwallet.apl.core.model;
+
+/**
+ * @author Andrii Boiarskyi
+ * @see
+ * @since 1.0.0
+ */
+public class Sort {
+    private final String order;
+
+    public Sort(String order) {
+        this.order = order;
+        if (!isASC() && !isDESC()) {
+            throw new IllegalArgumentException("Not allowed sort value: " + order);
+        }
+    }
+
+    public boolean isASC() {
+        return "ASC".equalsIgnoreCase(order);
+    }
+
+    public boolean isDESC() {
+        return "DESC".equalsIgnoreCase(order);
+    }
+
+    @Override
+    public String toString() {
+        return order;
+    }
+
+    public static Sort desc() {
+        return new Sort("DESC");
+    }
+
+    public static Sort asc() {
+        return new Sort("ASC");
+    }
+}

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/Blockchain.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/Blockchain.java
@@ -22,6 +22,7 @@ package com.apollocurrency.aplwallet.apl.core.service.blockchain;
 
 import com.apollocurrency.aplwallet.apl.core.model.Block;
 import com.apollocurrency.aplwallet.apl.core.model.EcBlockData;
+import com.apollocurrency.aplwallet.apl.core.model.Sort;
 import com.apollocurrency.aplwallet.apl.core.model.Transaction;
 import com.apollocurrency.aplwallet.apl.core.model.TransactionDbInfo;
 import com.apollocurrency.aplwallet.apl.core.transaction.PrunableTransaction;
@@ -160,7 +161,7 @@ public interface Blockchain {
     List<Transaction> getTransactions(long accountId, int numberOfConfirmations, byte type, byte subtype,
                                       int blockTimestamp, boolean withMessage, boolean phasedOnly, boolean nonPhasedOnly,
                                       int from, int to, boolean includeExpiredPrunable, boolean executedOnly,
-                                      boolean includePrivate,  boolean failedOnly, boolean nonFailedOnly);
+                                      boolean includePrivate, boolean failedOnly, boolean nonFailedOnly, Sort sort);
 
     List<Transaction> getBlockTransactions(long blockId);
 

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/BlockchainImpl.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/BlockchainImpl.java
@@ -20,10 +20,6 @@
 
 package com.apollocurrency.aplwallet.apl.core.service.blockchain;
 
-import com.apollocurrency.aplwallet.apl.core.entity.blockchain.TransactionEntity;
-import com.apollocurrency.aplwallet.apl.core.model.Block;
-import com.apollocurrency.aplwallet.apl.core.model.EcBlockData;
-import com.apollocurrency.aplwallet.apl.core.model.Transaction;
 import com.apollocurrency.aplwallet.apl.core.converter.db.BlockEntityToModelConverter;
 import com.apollocurrency.aplwallet.apl.core.converter.db.BlockModelToEntityConverter;
 import com.apollocurrency.aplwallet.apl.core.dao.appdata.ShardDao;
@@ -36,6 +32,10 @@ import com.apollocurrency.aplwallet.apl.core.entity.appdata.Shard;
 import com.apollocurrency.aplwallet.apl.core.entity.appdata.TransactionIndex;
 import com.apollocurrency.aplwallet.apl.core.entity.blockchain.BlockEntity;
 import com.apollocurrency.aplwallet.apl.core.entity.state.account.PublicKey;
+import com.apollocurrency.aplwallet.apl.core.model.Block;
+import com.apollocurrency.aplwallet.apl.core.model.EcBlockData;
+import com.apollocurrency.aplwallet.apl.core.model.Sort;
+import com.apollocurrency.aplwallet.apl.core.model.Transaction;
 import com.apollocurrency.aplwallet.apl.core.model.TransactionDbInfo;
 import com.apollocurrency.aplwallet.apl.core.service.appdata.TimeService;
 import com.apollocurrency.aplwallet.apl.core.service.state.account.PublicKeyDao;
@@ -698,11 +698,11 @@ public class BlockchainImpl implements Blockchain {
     public List<Transaction> getTransactions(long accountId, int numberOfConfirmations, byte type, byte subtype,
                                              int blockTimestamp, boolean withMessage, boolean phasedOnly, boolean nonPhasedOnly,
                                              int from, int to, boolean includeExpiredPrunable, boolean executedOnly,
-                                             boolean includePrivate,  boolean failedOnly, boolean nonFailedOnly) {
+                                             boolean includePrivate, boolean failedOnly, boolean nonFailedOnly, Sort sort) {
 
         return transactionService.getTransactionsCrossShardingByAccount(accountId, getHeight(), numberOfConfirmations, type, subtype,
             blockTimestamp, withMessage, phasedOnly, nonPhasedOnly,
-            from, to, includeExpiredPrunable, executedOnly, includePrivate, failedOnly, nonFailedOnly);
+            from, to, includeExpiredPrunable, executedOnly, includePrivate, failedOnly, nonFailedOnly, sort);
     }
 
     @Transactional(readOnly = true)

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/TransactionService.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/TransactionService.java
@@ -6,6 +6,7 @@ package com.apollocurrency.aplwallet.apl.core.service.blockchain;
 
 import com.apollocurrency.aplwallet.api.v2.model.TxReceipt;
 import com.apollocurrency.aplwallet.apl.core.entity.appdata.ChatInfo;
+import com.apollocurrency.aplwallet.apl.core.model.Sort;
 import com.apollocurrency.aplwallet.apl.core.model.Transaction;
 import com.apollocurrency.aplwallet.apl.core.model.TransactionDbInfo;
 import com.apollocurrency.aplwallet.apl.core.transaction.PrunableTransaction;
@@ -48,8 +49,6 @@ public interface TransactionService {
 
     Long getTransactionCount(int from, int to);
 
-    List<Transaction> getTransactionsByFilter(long accountId, byte type, byte subtype, int blockTimestamp, boolean withMessage, boolean phasedOnly, boolean nonPhasedOnly, int from, int to, boolean executedOnly, boolean includePrivate, int height, int prunableExpiration, boolean failedOnly, boolean nonFailedOnly);
-
     int getTransactionCountByFilter(long accountId, byte type, byte subtype, int blockTimestamp, boolean withMessage, boolean phasedOnly, boolean nonPhasedOnly, boolean executedOnly, boolean includePrivate, int height, int prunableExpiration, boolean failedOnly, boolean nonFailedOnly);
 
     List<Transaction> getTransactionsChatHistory(long account1, long account2, int from, int to);
@@ -78,5 +77,5 @@ public interface TransactionService {
 
     List<Transaction> getTransactionsCrossShardingByAccount(long accountId, int currentBlockChainHeight, int numberOfConfirmations, byte type, byte subtype,
                                                             int blockTimestamp, boolean withMessage, boolean phasedOnly, boolean nonPhasedOnly,
-                                                            int from, int to, boolean includeExpiredPrunable, boolean executedOnly, boolean includePrivate, boolean failedOnly, boolean nonFailedOnly);
+                                                            int from, int to, boolean includeExpiredPrunable, boolean executedOnly, boolean includePrivate, boolean failedOnly, boolean nonFailedOnly, Sort sort);
 }

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/TransactionServiceImpl.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/TransactionServiceImpl.java
@@ -8,24 +8,27 @@ import com.apollocurrency.aplwallet.api.v2.model.TxReceipt;
 import com.apollocurrency.aplwallet.apl.core.chainid.BlockchainConfig;
 import com.apollocurrency.aplwallet.apl.core.converter.db.TransactionEntityToModelConverter;
 import com.apollocurrency.aplwallet.apl.core.converter.db.TransactionModelToEntityConverter;
-import com.apollocurrency.aplwallet.apl.util.db.TransactionalDataSource;
 import com.apollocurrency.aplwallet.apl.core.dao.blockchain.TransactionDao;
-import com.apollocurrency.aplwallet.apl.core.model.Transaction;
+import com.apollocurrency.aplwallet.apl.core.db.DatabaseManager;
 import com.apollocurrency.aplwallet.apl.core.entity.appdata.ChatInfo;
 import com.apollocurrency.aplwallet.apl.core.entity.blockchain.TransactionEntity;
+import com.apollocurrency.aplwallet.apl.core.model.Sort;
+import com.apollocurrency.aplwallet.apl.core.model.Transaction;
 import com.apollocurrency.aplwallet.apl.core.model.TransactionDbInfo;
-import com.apollocurrency.aplwallet.apl.core.db.DatabaseManager;
 import com.apollocurrency.aplwallet.apl.core.service.appdata.TimeService;
 import com.apollocurrency.aplwallet.apl.core.shard.ShardDbExplorer;
 import com.apollocurrency.aplwallet.apl.core.shard.ShardManagement;
 import com.apollocurrency.aplwallet.apl.core.transaction.PrunableTransaction;
 import com.apollocurrency.aplwallet.apl.crypto.Convert;
 import com.apollocurrency.aplwallet.apl.util.cdi.Transactional;
+import com.apollocurrency.aplwallet.apl.util.db.TransactionalDataSource;
 import com.apollocurrency.aplwallet.apl.util.injectable.PropertiesHolder;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -150,12 +153,6 @@ public class TransactionServiceImpl implements TransactionService {
     }
 
     @Override
-    public List<Transaction> getTransactionsByFilter(long accountId, byte type, byte subtype, int blockTimestamp, boolean withMessage, boolean phasedOnly, boolean nonPhasedOnly, int from, int to, boolean executedOnly, boolean includePrivate, int height, int prunableExpiration,  boolean failedOnly, boolean nonFailedOnly) {
-        List<TransactionEntity> transactions = transactionDao.getTransactions(databaseManager.getDataSource(), accountId, type, subtype, blockTimestamp, withMessage, phasedOnly, nonPhasedOnly, from, to, executedOnly, includePrivate, height, prunableExpiration, failedOnly, nonFailedOnly);
-        return transactions.stream().map(toModelConverter).collect(Collectors.toList());
-    }
-
-    @Override
     public int getTransactionCountByFilter(long accountId, byte type, byte subtype, int blockTimestamp, boolean withMessage, boolean phasedOnly, boolean nonPhasedOnly, boolean executedOnly, boolean includePrivate, int height, int prunableExpiration,  boolean failedOnly, boolean nonFailedOnly) {
         return transactionDao.getTransactionCountByFilter(databaseManager.getDataSource(), accountId, type, subtype, blockTimestamp, withMessage, phasedOnly, nonPhasedOnly, executedOnly, includePrivate, height, prunableExpiration, failedOnly, nonFailedOnly);
     }
@@ -209,7 +206,7 @@ public class TransactionServiceImpl implements TransactionService {
     @Override
     public List<Transaction> getTransactionsCrossShardingByAccount(long accountId, int currentBlockChainHeight, int numberOfConfirmations, byte type, byte subtype,
                                                                    int blockTimestamp, boolean withMessage, boolean phasedOnly, boolean nonPhasedOnly,
-                                                                   int from, int to, boolean includeExpiredPrunable, boolean executedOnly, boolean includePrivate, boolean failedOnly, boolean nonFailedOnly) {
+                                                                   int from, int to, boolean includeExpiredPrunable, boolean executedOnly, boolean includePrivate, boolean failedOnly, boolean nonFailedOnly, Sort sort) {
         long start = System.currentTimeMillis();
         int height = numberOfConfirmations > 0 ? currentBlockChainHeight - numberOfConfirmations : Integer.MAX_VALUE;
         int prunableExpiration = Math.max(0, propertiesHolder.INCLUDE_EXPIRED_PRUNABLE() && includeExpiredPrunable ?
@@ -221,50 +218,27 @@ public class TransactionServiceImpl implements TransactionService {
         if (limit > 500) { // warn for too big values
             log.warn("Computed limit is BIGGER then 500 = {} !!", limit);
         }
-
-        // start fetch from main db
-        TransactionalDataSource currentDataSource = databaseManager.getDataSource();
-        List<TransactionEntity> transactions = transactionDao.getTransactions(
-            currentDataSource,
-            accountId, type, subtype,
-            blockTimestamp, withMessage, phasedOnly, nonPhasedOnly,
-            from, to, executedOnly, includePrivate, height, prunableExpiration, failedOnly, nonFailedOnly);
-        int foundCount = transactionDao.getTransactionCountByFilter(currentDataSource,
-            accountId, type, subtype,
-            blockTimestamp, withMessage, phasedOnly, nonPhasedOnly, executedOnly, includePrivate, height, prunableExpiration, failedOnly, nonFailedOnly);
-        log.trace("getTx() 2. fetched from mainDb, fetch=[{}] / foundCount={}, initLimit={}, accountId={}, type={}, subtype={}",
-            transactions.size(), foundCount, limit, accountId, type, subtype);
-
-        // check if all Txs are fetched from main db, continue inside shard dbs otherwise
-        if (transactions.size() < limit) {
-            // not all requested Tx were fetched from main, loop over shards
-            if (transactions.size() > 0) {
-                to -= (transactions.size() + from); // decrease limit by really fetched records
-                from = 0; // set to zero for shard db
-            } else {
-                from -= foundCount;
-                to -= foundCount;
-            }
-            // loop over all shard in descent order and fetch left Tx number
-            Iterator<TransactionalDataSource> fullDataSources = ((ShardManagement) databaseManager).getAllFullDataSourcesIterator();
+        List<TransactionEntity> transactions = new ArrayList<>();
+            Iterator<TransactionalDataSource> fullDataSources = ((ShardManagement) databaseManager)
+                .getAllSortedDataSourcesIterator(sort.isASC() ? Comparator.naturalOrder() : Comparator.reverseOrder());
             while (fullDataSources.hasNext()) {
                 TransactionalDataSource dataSource = fullDataSources.next();
                 // count Tx records before fetch Tx records
-                foundCount = transactionDao.getTransactionCountByFilter(dataSource,
+                int foundCount = transactionDao.getTransactionCountByFilter(dataSource,
                     accountId, type, subtype,
                     blockTimestamp, withMessage, phasedOnly, nonPhasedOnly, executedOnly, includePrivate, height, prunableExpiration, failedOnly, nonFailedOnly);
                 log.trace("countTx 3. DS={}, from={} to={}, foundCount={} (skip='{}')\naccountId={}, type={}, subtype={}",
                     dataSource.getDbIdentity(), from, to, foundCount, (foundCount <= 0),
                     accountId, type, subtype);
                 if (foundCount == 0) {
-                    continue; // skip shard without any suitable records
+                    continue; // skip data source without any suitable records
                 }
                 // because count is > 0 then try to fetch Tx records from shard db
                 List<TransactionEntity> fetchedTxs = transactionDao.getTransactions(
                     dataSource,
                     accountId, type, subtype,
                     blockTimestamp, withMessage, phasedOnly, nonPhasedOnly,
-                    from, to, executedOnly, includePrivate, height, prunableExpiration, failedOnly, nonFailedOnly);
+                    from, to, executedOnly, includePrivate, height, prunableExpiration, failedOnly, nonFailedOnly, sort);
                 log.trace("getTx() 4. DS={} fetched [{}] (foundCount={}) from={}, to={}", dataSource.getDbIdentity(),
                     fetchedTxs.size(), foundCount, from, to);
                 if (fetchedTxs.isEmpty()) {
@@ -279,7 +253,7 @@ public class TransactionServiceImpl implements TransactionService {
                     break;
                 }
             }
-        }
+//        }
         log.trace("Tx number Requested / Loaded : [{}] / [{}] = in {} ms", limit, transactions.size(), System.currentTimeMillis() - start);
         return transactions.stream().map(toModelConverter).collect(Collectors.toList());
     }

--- a/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/shard/ShardManagement.java
+++ b/apl-core/src/main/java/com/apollocurrency/aplwallet/apl/core/shard/ShardManagement.java
@@ -8,6 +8,7 @@ import com.apollocurrency.aplwallet.apl.db.updater.DBUpdater;
 import com.apollocurrency.aplwallet.apl.util.db.TransactionalDataSource;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
@@ -92,6 +93,15 @@ public interface ShardManagement {
      * @return list of full shard data sources
      */
     Iterator<TransactionalDataSource> getAllFullDataSourcesIterator();
+
+
+    /**
+     * Return Iterator for all data sources, including full shard data sources with the current data source, sorted using
+     * specified comparator.
+     * <p>Default order is from earlier shards to recent, last is current datasource</p>
+     * @return all data sources iterator sorted using specified comparator
+     */
+    Iterator<TransactionalDataSource> getAllSortedDataSourcesIterator(Comparator<TransactionalDataSource> comparator);
 
     /**
      * Close all datasources related to shards, this method will close all opened datasources excluding current main datasource

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/dao/blockchain/TransactionDaoTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/dao/blockchain/TransactionDaoTest.java
@@ -4,8 +4,6 @@
 
 package com.apollocurrency.aplwallet.apl.core.dao.blockchain;
 
-import com.apollocurrency.aplwallet.apl.core.model.Transaction;
-import com.apollocurrency.aplwallet.apl.core.service.blockchain.TransactionBuilderFactory;
 import com.apollocurrency.aplwallet.apl.core.chainid.BlockchainConfig;
 import com.apollocurrency.aplwallet.apl.core.converter.db.PrunableTxRowMapper;
 import com.apollocurrency.aplwallet.apl.core.converter.db.TransactionEntityRowMapper;
@@ -13,13 +11,16 @@ import com.apollocurrency.aplwallet.apl.core.converter.db.TransactionEntityToMod
 import com.apollocurrency.aplwallet.apl.core.converter.db.TransactionModelToEntityConverter;
 import com.apollocurrency.aplwallet.apl.core.converter.db.TxReceiptRowMapper;
 import com.apollocurrency.aplwallet.apl.core.dao.DbContainerBaseTest;
+import com.apollocurrency.aplwallet.apl.core.db.DatabaseManager;
 import com.apollocurrency.aplwallet.apl.core.entity.appdata.ChatInfo;
 import com.apollocurrency.aplwallet.apl.core.entity.blockchain.TransactionEntity;
+import com.apollocurrency.aplwallet.apl.core.model.Sort;
+import com.apollocurrency.aplwallet.apl.core.model.Transaction;
 import com.apollocurrency.aplwallet.apl.core.model.TransactionDbInfo;
-import com.apollocurrency.aplwallet.apl.core.db.DatabaseManager;
 import com.apollocurrency.aplwallet.apl.core.service.appdata.TimeService;
 import com.apollocurrency.aplwallet.apl.core.service.blockchain.Blockchain;
 import com.apollocurrency.aplwallet.apl.core.service.blockchain.BlockchainImpl;
+import com.apollocurrency.aplwallet.apl.core.service.blockchain.TransactionBuilderFactory;
 import com.apollocurrency.aplwallet.apl.core.service.prunable.PrunableMessageService;
 import com.apollocurrency.aplwallet.apl.core.service.state.PhasingPollService;
 import com.apollocurrency.aplwallet.apl.core.transaction.PrunableTransaction;
@@ -283,62 +284,62 @@ class TransactionDaoTest extends DbContainerBaseTest {
 
     @Test
     void testGetTransactionsByAccountId() {
-        List<TransactionEntity> transactions = dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_1.getSenderId(), (byte) 8, (byte) -1, 0, false, false, false, 0, Integer.MAX_VALUE, false, true, Integer.MAX_VALUE, 0, false, false);
+        List<TransactionEntity> transactions = dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_1.getSenderId(), (byte) 8, (byte) -1, 0, false, false, false, 0, Integer.MAX_VALUE, false, true, Integer.MAX_VALUE, 0, false, false, Sort.desc());
         assertEquals(List.of(td.TRANSACTION_12, td.TRANSACTION_11, td.TRANSACTION_7), toModelConverter.convert(transactions));
     }
 
     @Test
     void testGetTransactionsWithPhasingOnlyAndNonPhasedOnly() {
-        assertThrows(IllegalArgumentException.class, () -> dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_1.getSenderId(), (byte) 8, (byte) -1, 0, false, true, true, 0, Integer.MAX_VALUE, false, true, Integer.MAX_VALUE, 0, false, false));
+        assertThrows(IllegalArgumentException.class, () -> dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_1.getSenderId(), (byte) 8, (byte) -1, 0, false, true, true, 0, Integer.MAX_VALUE, false, true, Integer.MAX_VALUE, 0, false, false, Sort.desc()));
     }
 
     @Test
     void testGetPrivateTransactionsWhenIncludePrivateIsFalse() {
-        assertThrows(RuntimeException.class, () -> dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_1.getSenderId(),  (byte) 0, (byte) 1, 0, false, true, false, 0, Integer.MAX_VALUE, false, false, Integer.MAX_VALUE, 0, false, false));
+        assertThrows(RuntimeException.class, () -> dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_1.getSenderId(),  (byte) 0, (byte) 1, 0, false, true, false, 0, Integer.MAX_VALUE, false, false, Integer.MAX_VALUE, 0, false, false, Sort.desc()));
     }
 
     @Test
     void testGetPhasedTransactions() {
-        List<TransactionEntity> transactions = dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_1.getSenderId(), (byte) 0, (byte) 0, 0, false, true, false, 0, Integer.MAX_VALUE, false, true, Integer.MAX_VALUE, 0, false, false);
+        List<TransactionEntity> transactions = dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_1.getSenderId(), (byte) 0, (byte) 0, 0, false, true, false, 0, Integer.MAX_VALUE, false, true, Integer.MAX_VALUE, 0, false, false, Sort.desc());
         assertEquals(List.of(td.TRANSACTION_13), toModelConverter.convert(transactions));
     }
 
     @Test
     void testGetAllNotPhasedTransactionsWithPagination() {
-        List<TransactionEntity> transactions = dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_1.getSenderId(),  (byte) 0, (byte) 0, 0, false, false, true, 1, 3, false, true, td.TRANSACTION_7.getHeight() - 1, 0, false, false);
+        List<TransactionEntity> transactions = dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_1.getSenderId(),  (byte) 0, (byte) 0, 0, false, false, true, 1, 3, false, true, td.TRANSACTION_7.getHeight() - 1, 0, false, false, Sort.desc());
         assertEquals(List.of(td.TRANSACTION_5, td.TRANSACTION_4, td.TRANSACTION_3), toModelConverter.convert(transactions));
     }
 
     @Test
     void testGetExecutedOnlyTransactions() {
-        List<TransactionEntity> transactions = dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_1.getSenderId(), (byte) 0, (byte) 0, td.TRANSACTION_3.getBlockTimestamp() + 1, false, false, false, 0, Integer.MAX_VALUE, true, false, Integer.MAX_VALUE, 0, false, false);
+        List<TransactionEntity> transactions = dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_1.getSenderId(), (byte) 0, (byte) 0, td.TRANSACTION_3.getBlockTimestamp() + 1, false, false, false, 0, Integer.MAX_VALUE, true, false, Integer.MAX_VALUE, 0, false, false, Sort.desc());
 
         assertEquals(List.of(td.TRANSACTION_9, td.TRANSACTION_8, td.TRANSACTION_6, td.TRANSACTION_5, td.TRANSACTION_4), toModelConverter.convert(transactions));
     }
 
     @Test
     void testGetTransactionsWithMessage() {
-        List<TransactionEntity> transactions = dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_1.getSenderId(), (byte) 0, (byte) 0, 0, true, false, false, 0, Integer.MAX_VALUE, false, true, Integer.MAX_VALUE, 0, false, false);
+        List<TransactionEntity> transactions = dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_1.getSenderId(), (byte) 0, (byte) 0, 0, true, false, false, 0, Integer.MAX_VALUE, false, true, Integer.MAX_VALUE, 0, false, false, Sort.desc());
         assertEquals(List.of(td.TRANSACTION_13), toModelConverter.convert(transactions));
-        transactions = dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_14.getSenderId(), (byte) -1, (byte) -1, 0, true, false, false, 0, Integer.MAX_VALUE, false, false, Integer.MAX_VALUE, 0, false, false);
+        transactions = dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_14.getSenderId(), (byte) -1, (byte) -1, 0, true, false, false, 0, Integer.MAX_VALUE, false, false, Integer.MAX_VALUE, 0, false, false, Sort.desc());
         assertEquals(List.of(td.TRANSACTION_14), toModelConverter.convert(transactions));
     }
 
     @Test
     void testGetFailedOnlyTransactions() {
-        List<TransactionEntity> transactions = dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_1.getSenderId(), (byte) -1, (byte) -1, 0, false, false, false, 0, Integer.MAX_VALUE, false, true, Integer.MAX_VALUE, 0, true, false);
+        List<TransactionEntity> transactions = dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_1.getSenderId(), (byte) -1, (byte) -1, 0, false, false, false, 0, Integer.MAX_VALUE, false, true, Integer.MAX_VALUE, 0, true, false, Sort.desc());
 
         assertEquals(List.of(td.TRANSACTION_11), toModelConverter.convert(transactions));
 
 
-        transactions = dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_10.getSenderId(), (byte) -1, (byte) -1, 0, false, false, false, 0, Integer.MAX_VALUE, false, false, Integer.MAX_VALUE, 0, true, false);
+        transactions = dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_10.getSenderId(), (byte) -1, (byte) -1, 0, false, false, false, 0, Integer.MAX_VALUE, false, false, Integer.MAX_VALUE, 0, true, false, Sort.desc());
 
         assertEquals(List.of(td.TRANSACTION_10), toModelConverter.convert(transactions));
     }
 
     @Test
     void testGetNotFailedOnlyTransactions() {
-        List<TransactionEntity> transactions = dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_1.getSenderId(), (byte) -1, (byte) -1, 0, false, false, false, 0, Integer.MAX_VALUE, false, true, Integer.MAX_VALUE, 0, false, true);
+        List<TransactionEntity> transactions = dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_1.getSenderId(), (byte) -1, (byte) -1, 0, false, false, false, 0, Integer.MAX_VALUE, false, true, Integer.MAX_VALUE, 0, false, true, Sort.desc());
 
         List<Transaction> expected = new ArrayList<>(List.of(td.TRANSACTION_0, td.TRANSACTION_1, td.TRANSACTION_2, td.TRANSACTION_3,
             td.TRANSACTION_4, td.TRANSACTION_5, td.TRANSACTION_6, td.TRANSACTION_7, td.TRANSACTION_8, td.TRANSACTION_9, td.TRANSACTION_12, td.TRANSACTION_13));
@@ -346,14 +347,28 @@ class TransactionDaoTest extends DbContainerBaseTest {
         assertEquals(expected, toModelConverter.convert(transactions));
 
 
-        transactions = dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_10.getSenderId(), (byte) -1, (byte) -1, 0, false, false, false, 0, Integer.MAX_VALUE, false, false, Integer.MAX_VALUE, 0, false, true);
+        transactions = dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_10.getSenderId(), (byte) -1, (byte) -1, 0, false, false, false, 0, Integer.MAX_VALUE, false, false, Integer.MAX_VALUE, 0, false, true, Sort.desc());
 
         assertEquals(List.of(), toModelConverter.convert(transactions));
     }
 
     @Test
+    void testGetTransactions_withASCSort() {
+        List<TransactionEntity> transactions = dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_2.getSenderId(), (byte) -1, (byte) -1, 0, false, false, false, 0, Integer.MAX_VALUE, false, true, Integer.MAX_VALUE, 0, false, false, Sort.asc());
+
+        List<Transaction> expected = new ArrayList<>(List.of(td.TRANSACTION_0, td.TRANSACTION_1, td.TRANSACTION_2, td.TRANSACTION_3,
+            td.TRANSACTION_4, td.TRANSACTION_5, td.TRANSACTION_6, td.TRANSACTION_7, td.TRANSACTION_8, td.TRANSACTION_9, td.TRANSACTION_11, td.TRANSACTION_12, td.TRANSACTION_13));
+        assertEquals(expected, toModelConverter.convert(transactions));
+
+
+        transactions = dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_2.getSenderId(), (byte) -1, (byte) -1, 0, false, false, false, 5, 7, false, false, Integer.MAX_VALUE, 0, false, false, Sort.asc());
+
+        assertEquals(List.of(td.TRANSACTION_5, td.TRANSACTION_6, td.TRANSACTION_7), toModelConverter.convert(transactions));
+    }
+
+    @Test
     void testGetNotFailedOnlyAndFailedOnlyTransactions() {
-        assertThrows(IllegalArgumentException.class, () -> dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_1.getSenderId(), (byte) -1, (byte) -1, 0, false, false, false, 0, Integer.MAX_VALUE, false, true, Integer.MAX_VALUE, 0, true, true));
+        assertThrows(IllegalArgumentException.class, () -> dao.getTransactions(extension.getDatabaseManager().getDataSource(), td.TRANSACTION_1.getSenderId(), (byte) -1, (byte) -1, 0, false, false, false, 0, Integer.MAX_VALUE, false, true, Integer.MAX_VALUE, 0, true, true, Sort.desc()));
     }
 
     @Test

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/db/DatabaseManagerTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/db/DatabaseManagerTest.java
@@ -35,6 +35,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -285,4 +286,34 @@ class DatabaseManagerTest extends DBContainerRootTest {
 
     }
 
+    @Test
+    void getSortedDatasources_ASC() {
+        Iterator<TransactionalDataSource> iterator = databaseManager.getAllSortedDataSourcesIterator(Comparator.naturalOrder());
+        List<TransactionalDataSource> dataSources = new ArrayList<>();
+        while (iterator.hasNext()) {
+            dataSources.add(iterator.next());
+        }
+        assertEquals(3, dataSources.size());
+        assertFalse(dataSources.get(0).getDbIdentity().isEmpty());
+        assertEquals("apl_blockchain_b5d7b6_shard_2", dataSources.get(0).getDbIdentity().get());
+        assertFalse(dataSources.get(1).getDbIdentity().isEmpty());
+        assertEquals("apl_blockchain_b5d7b6_shard_3", dataSources.get(1).getDbIdentity().get());
+        assertTrue(dataSources.get(2).getDbIdentity().isEmpty()); // main data source
+    }
+
+    @Test
+    void getSortedDatasources_DESC() {
+        Iterator<TransactionalDataSource> iterator = databaseManager.getAllSortedDataSourcesIterator(Comparator.reverseOrder());
+        List<TransactionalDataSource> dataSources = new ArrayList<>();
+        while (iterator.hasNext()) {
+            dataSources.add(iterator.next());
+        }
+        assertEquals(3, dataSources.size());
+        assertTrue(dataSources.get(0).getDbIdentity().isEmpty()); // main data source
+        assertFalse(dataSources.get(1).getDbIdentity().isEmpty());
+        assertEquals("apl_blockchain_b5d7b6_shard_3", dataSources.get(1).getDbIdentity().get());
+        assertFalse(dataSources.get(2).getDbIdentity().isEmpty());
+        assertEquals("apl_blockchain_b5d7b6_shard_2", dataSources.get(2).getDbIdentity().get());
+
+    }
 }

--- a/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/BlockchainTest.java
+++ b/apl-core/src/test/java/com/apollocurrency/aplwallet/apl/core/service/blockchain/BlockchainTest.java
@@ -6,6 +6,7 @@ package com.apollocurrency.aplwallet.apl.core.service.blockchain;
 
 import com.apollocurrency.aplwallet.apl.core.model.Block;
 import com.apollocurrency.aplwallet.apl.core.model.EcBlockData;
+import com.apollocurrency.aplwallet.apl.core.model.Sort;
 import com.apollocurrency.aplwallet.apl.core.model.Transaction;
 import com.apollocurrency.aplwallet.apl.core.cache.NullCacheProducerForTests;
 import com.apollocurrency.aplwallet.apl.core.chainid.BlockchainConfig;
@@ -917,7 +918,7 @@ class BlockchainTest extends DBContainerRootTest {
         doReturn(txd.TRANSACTION_14.getTimestamp() + timeOffset).when(timeService).getEpochTime();
         doReturn(timeOffset + 1).when(blockchainConfig).getMinPrunableLifetime();
 
-        List<Transaction> transactions = blockchain.getTransactions(txd.TRANSACTION_14.getSenderId(), 0, (byte) -1, (byte) -1, 0, true, false, false, 0, Integer.MAX_VALUE, false, false, true, false, false);
+        List<Transaction> transactions = blockchain.getTransactions(txd.TRANSACTION_14.getSenderId(), 0, (byte) -1, (byte) -1, 0, true, false, false, 0, Integer.MAX_VALUE, false, false, true, false, false, Sort.desc());
 
         assertEquals(List.of(txd.TRANSACTION_14), transactions);
     }
@@ -930,7 +931,7 @@ class BlockchainTest extends DBContainerRootTest {
         doReturn(txd.TRANSACTION_14.getTimestamp() + timeOffset).when(timeService).getEpochTime();
         doReturn(timeOffset + 1).when(blockchainConfig).getMinPrunableLifetime();
 
-        List<Transaction> transactions = blockchain.getTransactions(txd.TRANSACTION_14.getSenderId(), 0, (byte) -1, (byte) -1, 0, true, false, false, 0, Integer.MAX_VALUE, false, false, true, false, false);
+        List<Transaction> transactions = blockchain.getTransactions(txd.TRANSACTION_14.getSenderId(), 0, (byte) -1, (byte) -1, 0, true, false, false, 0, Integer.MAX_VALUE, false, false, true, false, false, Sort.desc());
 
         assertEquals(List.of(txd.TRANSACTION_14), transactions);
     }
@@ -943,7 +944,7 @@ class BlockchainTest extends DBContainerRootTest {
         doReturn(txd.TRANSACTION_14.getTimestamp() + timeOffset).when(timeService).getEpochTime();
         doReturn(timeOffset).when(blockchainConfig).getMinPrunableLifetime();
 
-        List<Transaction> transactions = blockchain.getTransactions(txd.TRANSACTION_14.getSenderId(), 0, (byte) -1, (byte) -1, 0, true, false, false, 0, Integer.MAX_VALUE, false, false, true, false, false);
+        List<Transaction> transactions = blockchain.getTransactions(txd.TRANSACTION_14.getSenderId(), 0, (byte) -1, (byte) -1, 0, true, false, false, 0, Integer.MAX_VALUE, false, false, true, false, false, Sort.desc());
 
         assertEquals(List.of(), transactions);
 
@@ -955,12 +956,12 @@ class BlockchainTest extends DBContainerRootTest {
 
         List<Transaction> transactions = blockchain.getTransactions(txd.TRANSACTION_2.getSenderId(), txd.TRANSACTION_14.getHeight() - txd.TRANSACTION_8.getHeight() + 1,
             (byte) -1, (byte) -1, 0, false, false, false,
-            0, Integer.MAX_VALUE, false, false, true, false, false);
+            0, Integer.MAX_VALUE, false, false, true, false, false, Sort.desc());
         assertEquals(List.of(txd.TRANSACTION_6, txd.TRANSACTION_5, txd.TRANSACTION_4, txd.TRANSACTION_3, txd.TRANSACTION_2), transactions);
 
         transactions = blockchain.getTransactions(txd.TRANSACTION_2.getSenderId(), txd.TRANSACTION_14.getHeight() - txd.TRANSACTION_8.getHeight() + 1,
             (byte) -1, (byte) -1, 0, false, false, false,
-            3, 5, false, false, true, false, false);
+            3, 5, false, false, true, false, false, Sort.desc());
         assertEquals(List.of(txd.TRANSACTION_3, txd.TRANSACTION_2), transactions);
     }
 
@@ -969,7 +970,7 @@ class BlockchainTest extends DBContainerRootTest {
         blockchain.setLastBlock(btd.BLOCK_13);
 
         List<Transaction> transactions = blockchain.getTransactions(txd.TRANSACTION_2.getSenderId(), 0, (byte) 0, (byte) 1, 0, false, false, false,
-            0, Integer.MAX_VALUE, false, false, true, false, false);
+            0, Integer.MAX_VALUE, false, false, true, false, false, Sort.desc());
         // candidates by type+subtype are TR_12, TR_9, TR_7, TR_3, TR_2
         assertEquals(List.of(txd.TRANSACTION_13, txd.TRANSACTION_9, txd.TRANSACTION_7, txd.TRANSACTION_3, txd.TRANSACTION_2), transactions);
     }
@@ -980,26 +981,26 @@ class BlockchainTest extends DBContainerRootTest {
         blockchain.setLastBlock(btd.BLOCK_13);
 
         List<Transaction> transactions = blockchain.getTransactions(txd.TRANSACTION_2.getSenderId(), 0, (byte) -1, (byte) -1, 0, false, false, false,
-            8, Integer.MAX_VALUE, false, false, true, false, false);
+            8, Integer.MAX_VALUE, false, false, true, false, false, Sort.desc());
         assertEquals(List.of(txd.TRANSACTION_4, txd.TRANSACTION_3, txd.TRANSACTION_2), transactions);
 
         transactions = blockchain.getTransactions(txd.TRANSACTION_2.getSenderId(), 0, (byte) 0, (byte) 1, 0, false, false, false,
-            1, Integer.MAX_VALUE, false, false, true, false, false);
+            1, Integer.MAX_VALUE, false, false, true, false, false, Sort.desc());
         // candidates by type+subtype are TR_13, TR_9, TR_7, TR_3, TR_2
         assertEquals(List.of(txd.TRANSACTION_9, txd.TRANSACTION_7, txd.TRANSACTION_3, txd.TRANSACTION_2), transactions);
 
         transactions = blockchain.getTransactions(txd.TRANSACTION_2.getSenderId(), 0, (byte) 0, (byte) 1, 0, false, false, false,
-            2, Integer.MAX_VALUE, false, false, true, false, false);
+            2, Integer.MAX_VALUE, false, false, true, false, false, Sort.desc());
         // candidates by type+subtype are TR_13, TR_9, TR_7, TR_3, TR_2
         assertEquals(List.of(txd.TRANSACTION_7, txd.TRANSACTION_3, txd.TRANSACTION_2), transactions);
 
         transactions = blockchain.getTransactions(txd.TRANSACTION_2.getSenderId(), 0, (byte) 0, (byte) 1, 0, false, false, false,
-            3, Integer.MAX_VALUE, false, false, true, false, false);
+            3, Integer.MAX_VALUE, false, false, true, false, false, Sort.desc());
         // candidates by type+subtype are TR_13, TR_9, TR_7, TR_3, TR_2
         assertEquals(List.of(txd.TRANSACTION_3, txd.TRANSACTION_2), transactions);
 
         transactions = blockchain.getTransactions(txd.TRANSACTION_2.getSenderId(), 0, (byte) 0, (byte) 1, 0, false, false, false,
-            4, Integer.MAX_VALUE, false, false, true, false, false);
+            4, Integer.MAX_VALUE, false, false, true, false, false, Sort.desc());
         // candidates by type+subtype are TR_13, TR_9, TR_7, TR_3, TR_2
         assertEquals(List.of(txd.TRANSACTION_2), transactions);
     }
@@ -1007,33 +1008,33 @@ class BlockchainTest extends DBContainerRootTest {
     @Test
     void testGetTransactionsFromDifferentDataSourcesSkipSecondShard() {
         List<Transaction> transactions = blockchain.getTransactions(txd.TRANSACTION_10.getSenderId(), 0, (byte) 0, (byte) 1, 0, false, false, false,
-            0, Integer.MAX_VALUE, false, false, true, false, false);
+            0, Integer.MAX_VALUE, false, false, true, false, false, Sort.desc());
         assertEquals(List.of(txd.TRANSACTION_10, txd.TRANSACTION_1, txd.TRANSACTION_0), transactions);
 
         transactions = blockchain.getTransactions(txd.TRANSACTION_10.getSenderId(), 0, (byte) 0, (byte) 1, 0, false, false, false,
-            1, 1, false, false, true, false, false);
+            1, 1, false, false, true, false, false, Sort.desc());
         assertEquals(List.of(txd.TRANSACTION_1), transactions);
     }
 
     @Test
     void testGetTransactionsFromDifferentDataSourcesWithLimit() {
         List<Transaction> transactions = blockchain.getTransactions(txd.TRANSACTION_2.getSenderId(), 0, (byte) 0, (byte) 1, 0, false, false, false,
-            0, 1, false, false, true, false, false);
+            0, 1, false, false, true, false, false, Sort.desc());
         // candidates by type+subtype are TR_13, TR_9, TR_7, TR_3, TR_2
         assertEquals(List.of(txd.TRANSACTION_13, txd.TRANSACTION_9), transactions);
 
         transactions = blockchain.getTransactions(txd.TRANSACTION_2.getSenderId(), 0, (byte) 0, (byte) 1, 0, false, false, false,
-            0, 2, false, false, true, false, false);
+            0, 2, false, false, true, false, false, Sort.desc());
         // candidates by type+subtype are TR_13, TR_9, TR_7, TR_3, TR_2
         assertEquals(List.of(txd.TRANSACTION_13, txd.TRANSACTION_9, txd.TRANSACTION_7), transactions);
 
         transactions = blockchain.getTransactions(txd.TRANSACTION_2.getSenderId(), 0, (byte) 0, (byte) 1, 0, false, false, false,
-            0, 3, false, false, true, false, false);
+            0, 3, false, false, true, false, false, Sort.desc());
         // candidates by type+subtype are TR_13, TR_9, TR_7, TR_3, TR_2
         assertEquals(List.of(txd.TRANSACTION_13, txd.TRANSACTION_9, txd.TRANSACTION_7, txd.TRANSACTION_3), transactions);
 
         transactions = blockchain.getTransactions(txd.TRANSACTION_2.getSenderId(), 0, (byte) 0, (byte) 1, 0, false, false, false,
-            0, 4, false, false, true, false, false);
+            0, 4, false, false, true, false, false, Sort.desc());
         // candidates by type+subtype are TR_13, TR_9, TR_7, TR_3, TR_2
         assertEquals(List.of(txd.TRANSACTION_13, txd.TRANSACTION_9, txd.TRANSACTION_7, txd.TRANSACTION_3, txd.TRANSACTION_2), transactions);
     }
@@ -1043,28 +1044,47 @@ class BlockchainTest extends DBContainerRootTest {
         blockchain.setLastBlock(btd.BLOCK_13);
 
         List<Transaction> transactions = blockchain.getTransactions(txd.TRANSACTION_2.getSenderId(), 0, (byte) -1, (byte) -1, 0, false, false, false,
-            8, 10, false, false, true, false, false);
+            8, 10, false, false, true, false, false, Sort.desc());
         assertEquals(List.of(txd.TRANSACTION_4, txd.TRANSACTION_3, txd.TRANSACTION_2), transactions);
         // candidates by type+subtype are TR_13, TR_9, TR_7, TR_3, TR_2
         transactions = blockchain.getTransactions(txd.TRANSACTION_2.getSenderId(), 0, (byte) 0, (byte) 1, 0, false, false, false,
-            3, 4, false, false, true, false, false);
+            3, 4, false, false, true, false, false, Sort.desc());
         // candidates by type+subtype are TR_13, TR_9, TR_7, TR_3, TR_2
         assertEquals(List.of(txd.TRANSACTION_3, txd.TRANSACTION_2), transactions);
 
         transactions = blockchain.getTransactions(txd.TRANSACTION_2.getSenderId(), 0, (byte) 0, (byte) 1, 0, false, false, false,
-            3, 5, false, false, true, false, false);
+            3, 5, false, false, true, false, false, Sort.desc());
         // candidates by type+subtype are TR_13, TR_9, TR_7, TR_3, TR_2
         assertEquals(List.of(txd.TRANSACTION_3, txd.TRANSACTION_2), transactions);
 
         transactions = blockchain.getTransactions(txd.TRANSACTION_2.getSenderId(), 0, (byte) 0, (byte) 1, 0, false, false, false,
-            4, 5, false, false, true, false, false);
+            4, 5, false, false, true, false, false, Sort.desc());
         // candidates by type+subtype are TR_13, TR_9, TR_7, TR_3, TR_2
         assertEquals(List.of(txd.TRANSACTION_2), transactions);
 
         transactions = blockchain.getTransactions(txd.TRANSACTION_2.getSenderId(), 0, (byte) 0, (byte) 1, 0, false, false, false,
-            2, 4, false, false, true, false, false);
+            2, 4, false, false, true, false, false, Sort.desc());
         // candidates by type+subtype are TR_13, TR_9, TR_7, TR_3, TR_2
         assertEquals(List.of(txd.TRANSACTION_7, txd.TRANSACTION_3, txd.TRANSACTION_2), transactions);
+
+    }
+
+
+
+    @Test
+    void testGetTransactionsFromDifferentDataSourcesWithPagination_ASC_sort() {
+        blockchain.setLastBlock(btd.BLOCK_13);
+        // candidates by account are TX_2-TX_9, TX_11-13
+
+        List<Transaction> transactions = blockchain.getTransactions(txd.TRANSACTION_2.getSenderId(), 0, (byte) -1, (byte) -1, 0, false, false, false,
+            0, Integer.MAX_VALUE, false, false, true, false, false, Sort.asc());
+        assertEquals(List.of(txd.TRANSACTION_2, txd.TRANSACTION_3, txd.TRANSACTION_4, txd.TRANSACTION_5, txd.TRANSACTION_6,
+            txd.TRANSACTION_7, txd.TRANSACTION_8, txd.TRANSACTION_9, txd.TRANSACTION_11, txd.TRANSACTION_12, txd.TRANSACTION_13), transactions);
+
+        transactions = blockchain.getTransactions(txd.TRANSACTION_2.getSenderId(), 0, (byte) -1, (byte) -1, 0, false, false, false,
+            4, 7, false, false, true, false, false, Sort.asc());
+        assertEquals(List.of(txd.TRANSACTION_6, txd.TRANSACTION_7, txd.TRANSACTION_8, txd.TRANSACTION_9), transactions);
+
 
     }
 
@@ -1074,7 +1094,7 @@ class BlockchainTest extends DBContainerRootTest {
         blockchain.setLastBlock(btd.BLOCK_13);
 
         List<Transaction> transactions = blockchain.getTransactions(txd.TRANSACTION_2.getSenderId(), 0, (byte) -1, (byte) -1, 0, false, false, false,
-            4, 8, false, false, true, false, false);
+            4, 8, false, false, true, false, false, Sort.desc());
         assertEquals(List.of(txd.TRANSACTION_8, txd.TRANSACTION_7, txd.TRANSACTION_6, txd.TRANSACTION_5, txd.TRANSACTION_4), transactions);
     }
 
@@ -1083,7 +1103,7 @@ class BlockchainTest extends DBContainerRootTest {
         blockchain.setLastBlock(btd.BLOCK_13);
 
         List<Transaction> transactions = blockchain.getTransactions(txd.TRANSACTION_2.getSenderId(), 0, (byte) -1, (byte) -1,
-            0, false, false, false, 0, 0, false, false, true, false, false);
+            0, false, false, false, 0, 0, false, false, true, false, false, Sort.desc());
 
         assertEquals(List.of(txd.TRANSACTION_13), transactions);
     }

--- a/apl-utils/src/main/java/com/apollocurrency/aplwallet/apl/util/db/TransactionalDataSource.java
+++ b/apl-utils/src/main/java/com/apollocurrency/aplwallet/apl/util/db/TransactionalDataSource.java
@@ -24,7 +24,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  * Data source with Transaction support implemented by ThreadLocal connection management.
  * Should not be retrieved from CDI directly.
  */
-public class TransactionalDataSource extends DataSourceWrapper implements TransactionManagement {
+public class TransactionalDataSource extends DataSourceWrapper implements TransactionManagement, Comparable<TransactionalDataSource> {
     private static final Logger log = getLogger(TransactionalDataSource.class);
     private final ThreadLocal<DbConnectionWrapper> localConnection = new ThreadLocal<>();
     private final ThreadLocal<Set<TransactionCallback>> transactionCallback = new ThreadLocal<>();
@@ -275,6 +275,20 @@ public class TransactionalDataSource extends DataSourceWrapper implements Transa
             return new StartedConnection(begin(), false);
         }
     }
+
+    @Override
+    public int compareTo(TransactionalDataSource o) {
+        if (o.getDbIdentity().isEmpty()) {
+            return -1;
+        }
+        if (getDbIdentity().isEmpty()) {
+            return 1;
+        }
+        int ourId = Integer.parseInt(dbIdentity.substring(dbIdentity.lastIndexOf("_") + 1));
+        int theirId = Integer.parseInt(o.getDbIdentity().get().substring(o.getDbIdentity().get().lastIndexOf("_") + 1));
+        return Integer.compare(ourId, theirId);
+    }
+
     @Data
     public static class StartedConnection {
         @Getter


### PR DESCRIPTION
Motivation: for  APL Payment txs processing
* Keep a default desc sort
* Add new Sort option (ASC or DESC)
* Update test

 Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)